### PR TITLE
chore(repo): establish git convention guardrails

### DIFF
--- a/.cursor/skills/frontend-testing/SKILL.md
+++ b/.cursor/skills/frontend-testing/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: frontend-testing
+description: Frontend Testing Guide
+disable-model-invocation: true
+---
+
 # Frontend Testing Guide
 
 ## 1. Scope

--- a/.cursor/skills/git/SKILL.md
+++ b/.cursor/skills/git/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: git
+description: Standardizes Chatty Git workflow with Light GitFlow branching, Conventional Commits, PR rules, and release/hotfix flow. Use when creating branches, writing commits, opening PRs, preparing releases, or handling hotfixes in this repository.
+---
+
+# Git Convention for Chatty
+
+## When to apply
+
+Apply this skill for any Git operation in this repository, including branch naming, commit message writing, pull request preparation, release branching, and hotfix handling.
+
+## Repository defaults
+
+1. Branch model:
+   - `main`: stable, production-ready code only.
+   - `develop`: integration branch for ongoing work.
+   - `feature/<scope>-<short-description>`: standard feature branch off `develop`.
+   - `release/<version>`: release stabilization branch off `develop`.
+   - `hotfix/<scope>-<short-description>`: urgent production fix branch off `main`.
+
+2. Commit format (Conventional Commits):
+   - Required format: `<type>(<scope>): <subject>`
+   - Allowed types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `ci`, `build`, `perf`, `revert`.
+   - Prefer imperative present-tense subject (example: `add socket auth guard`).
+   - Breaking changes use `!` and a `BREAKING CHANGE:` footer.
+
+3. Scope taxonomy:
+   - Backend: `backend`, `auth`, `chatrooms`, `messages`, `websocket`, `scheduler`, `prisma`.
+   - Frontend: `frontend`, `chat`, `ui`, `router`, `state`, `pwa`.
+   - Cross-cutting: `repo`, `infra`, `deps`, `ci`, `docs`.
+
+4. Pull request defaults:
+   - PR title follows Conventional Commit format.
+   - Prefer one concern per PR.
+   - Prefer squash merge to keep `develop` and `main` history readable.
+
+## Required workflow
+
+Use this checklist while working:
+
+```markdown
+Git Task Checklist
+
+- [ ] Branch is created from the correct base (`develop` for features, `main` for hotfixes)
+- [ ] Branch name follows naming convention
+- [ ] Commits follow Conventional Commits with appropriate scope
+- [ ] PR title and body follow project template
+- [ ] Lint/typecheck/tests are run for affected app(s)
+- [ ] Merge target is correct (`develop` for feature, `main` for release/hotfix)
+- [ ] Back-merge/cherry-pick rules are applied after release/hotfix
+```
+
+## Branch and merge policy
+
+### Feature flow
+
+1. Update base branch:
+   - `git checkout develop`
+   - `git pull`
+2. Create branch:
+   - `git checkout -b feature/<scope>-<short-description>`
+3. Open PR to `develop`.
+4. Squash merge after approval and checks pass.
+
+### Release flow
+
+1. Create release branch from `develop`:
+   - `git checkout develop && git pull`
+   - `git checkout -b release/<version>`
+2. Allow only bugfix/docs/versioning commits on release branch.
+3. PR `release/<version>` to `main`.
+4. Tag in `main` with semantic version (`vX.Y.Z`).
+5. Merge `main` back into `develop` to keep histories aligned.
+
+### Hotfix flow
+
+1. Create hotfix branch from `main`:
+   - `git checkout main && git pull`
+   - `git checkout -b hotfix/<scope>-<short-description>`
+2. PR to `main` for urgent production fix.
+3. After merge to `main`, merge the same fix into `develop`.
+
+## Commit and PR templates
+
+### Commit examples
+
+- `feat(messages): add AI stream completion event`
+- `fix(auth): reject expired JWT on websocket handshake`
+- `refactor(frontend): split chat input state hook`
+- `docs(repo): clarify release and hotfix merge flow`
+
+### PR title examples
+
+- `feat(chat): add optimistic message placeholder`
+- `fix(websocket): handle reconnect room join race`
+- `chore(ci): enforce conventional commit format`
+
+### PR body template
+
+```markdown
+## Summary
+- <what changed>
+
+## Why
+- <problem or goal>
+
+## Test plan
+- [ ] backend: `npm run lint`
+- [ ] backend: `npm run test`
+- [ ] frontend: `npm run lint`
+- [ ] frontend: `npm run typecheck`
+- [ ] frontend: `npm run test`
+
+## Rollback notes
+- <how to safely revert if needed>
+```
+
+## Automation and guardrails
+
+Default automated checks for this repo:
+
+- Local `commit-msg` hook validates Conventional Commit format.
+- Local `pre-push` hook runs app checks depending on changed paths.
+- CI validates commit messages for push/PR ranges.
+
+Enable local hooks once per clone:
+
+```bash
+git config core.hooksPath .githooks
+chmod +x .githooks/commit-msg .githooks/pre-push scripts/ci/verify-commits.sh
+```
+
+If local hooks block progress for exceptional reasons, fix the issue rather than bypassing checks unless maintainers approve an exception.
+
+## Pilot and iteration loop
+
+Use this rollout loop for one sprint:
+
+1. Apply this workflow to all new branches.
+2. Track friction:
+   - ambiguous scope names
+   - branch naming complexity
+   - unnecessary check runtime
+3. At sprint end, adjust scope taxonomy or hook strictness while preserving:
+   - Light GitFlow branch model
+   - Conventional Commit format
+   - PR title/body standard
+
+Use [pilot-checklist.md](pilot-checklist.md) to run and review the first sprint consistently.

--- a/.cursor/skills/git/pilot-checklist.md
+++ b/.cursor/skills/git/pilot-checklist.md
@@ -1,0 +1,24 @@
+# Git Convention Pilot Checklist (1 Sprint)
+
+Use this during the first sprint after adopting `.cursor/skills/git/SKILL.md`.
+
+## Week 1 setup
+
+- [ ] All contributors run `git config core.hooksPath .githooks`
+- [ ] Hook scripts are executable (`chmod +x .githooks/commit-msg .githooks/pre-push scripts/ci/verify-commits.sh`)
+- [ ] New branches follow `feature/*`, `release/*`, `hotfix/*`
+- [ ] PR titles follow Conventional Commit format
+
+## During sprint
+
+- [ ] Track rejected commits by reason (format/scope/subject clarity)
+- [ ] Track PR title corrections requested in review
+- [ ] Track pre-push check runtime pain points
+- [ ] Track naming pain points for scope and branch descriptions
+
+## End-of-sprint retro
+
+- [ ] Decide if scope taxonomy needs edits
+- [ ] Decide if pre-push checks should be narrowed or expanded
+- [ ] Confirm release/hotfix flow was clear
+- [ ] Record agreed changes directly in `.cursor/skills/git/SKILL.md`

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,20 @@
+#!/usr/bin/env sh
+set -eu
+
+commit_msg_file="${1:-}"
+
+if [ -z "$commit_msg_file" ] || [ ! -f "$commit_msg_file" ]; then
+  echo "commit-msg hook: commit message file is missing."
+  exit 1
+fi
+
+first_line="$(sed -n '1p' "$commit_msg_file")"
+
+pattern='^(feat|fix|refactor|test|docs|chore|ci|build|perf|revert)(\([a-z0-9-]+\))?!?: .+'
+
+if ! printf '%s\n' "$first_line" | grep -Eq "$pattern"; then
+  echo "Invalid commit message format."
+  echo "Expected: <type>(<scope>): <subject>"
+  echo "Example: feat(messages): add AI stream completion event"
+  exit 1
+fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+set -eu
+
+upstream="$(git rev-parse --abbrev-ref --symbolic-full-name @{upstream} 2>/dev/null || true)"
+
+if [ -n "$upstream" ]; then
+  base="$(git merge-base HEAD "$upstream")"
+else
+  base="$(git merge-base HEAD origin/main 2>/dev/null || git rev-list --max-parents=0 HEAD)"
+fi
+
+changed_files="$(git diff --name-only "$base"...HEAD)"
+
+echo "$changed_files" | grep -q '^backend/' && {
+  echo "Running backend checks..."
+  (cd backend && npm run lint && npm run test)
+}
+
+echo "$changed_files" | grep -q '^frontend/' && {
+  echo "Running frontend checks..."
+  (cd frontend && npm run lint && npm run typecheck && npm run test)
+}
+
+echo "Pre-push checks passed."

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,43 @@
+---
+name: Bug report
+about: Report a reproducible bug
+title: "fix(scope): <short bug summary>"
+labels: bug
+assignees: ""
+---
+
+## Summary
+- What is broken?
+
+## Environment
+- App: backend / frontend / both
+- Branch/commit:
+- OS:
+- Node version:
+
+## Steps to reproduce
+1.
+2.
+3.
+
+## Expected behavior
+- What should happen?
+
+## Actual behavior
+- What happens instead?
+
+## Impact
+- Severity: low / medium / high / critical
+- User impact:
+
+## Evidence
+- Logs, screenshots, request/response payloads, stack traces
+
+## Proposed fix (optional)
+- Suggested direction
+
+## Definition of done
+- [ ] Repro added or documented
+- [ ] Fix implemented
+- [ ] Relevant tests added/updated
+- [ ] Docs updated if behavior changed

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,39 @@
+---
+name: Feature request
+about: Propose a new feature or enhancement
+title: "feat(scope): <short feature summary>"
+labels: enhancement
+assignees: ""
+---
+
+## Problem statement
+- What user/problem are we solving?
+
+## Proposed solution
+- What should we build?
+
+## Scope
+- In scope:
+- Out of scope:
+
+## API / UX notes
+- Backend changes:
+- Frontend changes:
+- Data model changes:
+
+## Alternatives considered
+- What options were considered and why not chosen?
+
+## Acceptance criteria
+- [ ] Criterion 1
+- [ ] Criterion 2
+- [ ] Criterion 3
+
+## Test plan
+- Unit:
+- Integration/E2E:
+- Manual verification:
+
+## Rollout / rollback
+- Release plan:
+- Rollback plan:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Summary
+- <what changed>
+
+## Why
+- <problem or goal>
+
+## Test plan
+- [ ] backend: `npm run lint`
+- [ ] backend: `npm run test`
+- [ ] frontend: `npm run lint`
+- [ ] frontend: `npm run typecheck`
+- [ ] frontend: `npm run test`
+- [ ] I only ran the checks relevant to my changed paths
+
+## Rollback notes
+- <how to safely revert if needed>
+
+## Scope checklist
+- [ ] PR title follows Conventional Commits (`type(scope): subject`)
+- [ ] This PR is focused on a single concern
+- [ ] I updated docs/tests for behavior changes

--- a/.github/workflows/git-convention.yml
+++ b/.github/workflows/git-convention.yml
@@ -26,11 +26,11 @@ jobs:
         run: |
           chmod +x scripts/ci/verify-commits.sh
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            scripts/ci/verify-commits.sh "origin/${{ github.base_ref }}" "HEAD"
+            scripts/ci/verify-commits.sh "origin/${{ github.base_ref }}" "${{ github.event.pull_request.head.sha }}"
           else
             BEFORE_SHA="${{ github.event.before }}"
             if [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ]; then
-              BEFORE_SHA="$(git rev-list --max-parents=0 HEAD | tail -n 1)"
+              BEFORE_SHA="$(git merge-base "${{ github.sha }}" "origin/main")"
             fi
             scripts/ci/verify-commits.sh "$BEFORE_SHA" "${{ github.sha }}"
           fi

--- a/.github/workflows/git-convention.yml
+++ b/.github/workflows/git-convention.yml
@@ -1,0 +1,36 @@
+name: Git Convention
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+  push:
+    branches:
+      - main
+      - develop
+      - "feature/**"
+      - "release/**"
+      - "hotfix/**"
+
+jobs:
+  verify-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate commit subjects
+        run: |
+          chmod +x scripts/ci/verify-commits.sh
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            scripts/ci/verify-commits.sh "origin/${{ github.base_ref }}" "HEAD"
+          else
+            BEFORE_SHA="${{ github.event.before }}"
+            if [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ]; then
+              BEFORE_SHA="$(git rev-list --max-parents=0 HEAD | tail -n 1)"
+            fi
+            scripts/ci/verify-commits.sh "$BEFORE_SHA" "${{ github.sha }}"
+          fi

--- a/backend/README.md
+++ b/backend/README.md
@@ -9,6 +9,12 @@ Chatty is a real-time, AI-based chat application backend built with **NestJS**, 
 - **Testing**: Jest & Supertest (Unit & E2E)
 - **Static Assets**: `@nestjs/serve-static` & `@nestjs/platform-express` (Multer) for image uploads
 
+## Git Workflow Convention
+
+Use the shared Git convention skill before creating branches, commits, and PRs:
+
+- `.cursor/skills/git/SKILL.md`
+
 ## Prerequisites
 - **Node.js** (v18+ recommended)
 - **MySQL** Server

--- a/scripts/ci/verify-commits.sh
+++ b/scripts/ci/verify-commits.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_ref="${1:-}"
+head_ref="${2:-HEAD}"
+
+if [[ -z "$base_ref" ]]; then
+  echo "Usage: scripts/ci/verify-commits.sh <base-ref> [head-ref]"
+  exit 1
+fi
+
+pattern='^(feat|fix|refactor|test|docs|chore|ci|build|perf|revert)(\([a-z0-9-]+\))?!?: .+'
+failed=0
+
+while IFS= read -r subject; do
+  if [[ -z "$subject" ]]; then
+    continue
+  fi
+
+  if [[ ! "$subject" =~ $pattern ]]; then
+    echo "Invalid commit subject: $subject"
+    failed=1
+  fi
+done < <(git log --format=%s "${base_ref}..${head_ref}")
+
+if [[ "$failed" -ne 0 ]]; then
+  echo "Commit convention check failed."
+  exit 1
+fi
+
+echo "Commit convention check passed."


### PR DESCRIPTION
## Summary
- add a shared git convention skill with Light GitFlow, Conventional Commit, and PR guidance
- add local `.githooks` checks for commit message format and path-aware pre-push validation
- add CI commit-subject validation and update PR template to enforce convention checks

## Why
- standardize branch/commit/PR practices so collaboration stays consistent and review quality improves
- prevent non-conforming commit history through local and CI guardrails
- close #1

## Test plan
- [ ] backend: `npm run lint`
- [ ] backend: `npm run test`
- [ ] frontend: `npm run lint`
- [ ] frontend: `npm run typecheck`
- [ ] frontend: `npm run test`
- [x] I only ran the checks relevant to my changed paths

## Rollback notes
- revert commit `b1d9fb9` to remove the introduced git convention docs/hooks/workflow changes

## Scope checklist
- [x] PR title follows Conventional Commits (`type(scope): subject`)
- [x] This PR is focused on a single concern
- [x] I updated docs/tests for behavior changes

Made with [Cursor](https://cursor.com)