### PR TITLE
ci(repo): ignore merge commits in commit subject validation

### DIFF
--- a/scripts/ci/verify-commits.sh
+++ b/scripts/ci/verify-commits.sh
@@ -21,7 +21,7 @@ while IFS= read -r subject; do
     echo "Invalid commit subject: $subject"
     failed=1
   fi
-done < <(git log --format=%s "${base_ref}..${head_ref}")
+done < <(git log --no-merges --format=%s "${base_ref}..${head_ref}")
 
 if [[ "$failed" -ne 0 ]]; then
   echo "Commit convention check failed."


### PR DESCRIPTION
## Summary
- update commit subject validation to skip merge commits via `git log --no-merges`

## Why
- protected branch PRs can include historical merge commits that are not conventional commit formatted
- validation should focus on authored commits, not synthetic merge subjects

## Test plan
- [x] verify script logic by inspection
- [ ] CI `verify-commits` passes on this PR

## Rollback notes
- revert this single commit if strict merge-subject enforcement is required

Made with [Cursor](https://cursor.com)