### PR TITLE
ci(repo): reduce duplicate workflow triggers

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -79,6 +79,8 @@ jobs:
     name: deploy-production
     runs-on: ubuntu-latest
     needs: build-and-push
+    environment:
+      name: production
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,8 @@ on:
       - develop
   push:
     branches:
+      - main
       - develop
-      - "feature/**"
-      - "release/**"
-      - "hotfix/**"
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - main
       - develop
-      - "feature/**"
-      - "release/**"
-      - "hotfix/**"
   pull_request:
     branches:
       - main

--- a/.github/workflows/git-convention.yml
+++ b/.github/workflows/git-convention.yml
@@ -9,9 +9,6 @@ on:
     branches:
       - main
       - develop
-      - "feature/**"
-      - "release/**"
-      - "hotfix/**"
 
 jobs:
   verify-commits:


### PR DESCRIPTION
## Summary
- reduce duplicate workflow executions by limiting `push` triggers to `main` and `develop` in CI, Git Convention, and CodeQL workflows
- keep PR-based validation on `develop`/`main` for feature branches
- attach `deploy-production` in CD workflow to `production` environment so environment secrets are available

## Why
- feature branch updates were running duplicate checks (`push` + `pull_request`) and increasing workflow noise/cost
- deploy job must be environment-bound to read production-scoped secrets

## Test plan
- [x] workflow lint clean
- [ ] PR checks green

Made with [Cursor](https://cursor.com)