### PR TITLE
ci(repo): force legacy scp mode for production deploy

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -110,8 +110,10 @@ jobs:
             echo "DEPLOY_PATH secret must be set (path to deploy folder on server)."
             exit 1
           fi
-          scp deploy/docker-compose.prod.yml deploy/scripts/deploy-prod.sh "${DEPLOY_USER}@${DEPLOY_HOST}:${DEPLOY_PATH}/"
-          ssh "${DEPLOY_USER}@${DEPLOY_HOST}" \
+          SSH_OPTS="-o BatchMode=yes -o StrictHostKeyChecking=yes"
+          ssh ${SSH_OPTS} "${DEPLOY_USER}@${DEPLOY_HOST}" "mkdir -p '${DEPLOY_PATH}'"
+          scp -O ${SSH_OPTS} deploy/docker-compose.prod.yml deploy/scripts/deploy-prod.sh "${DEPLOY_USER}@${DEPLOY_HOST}:${DEPLOY_PATH}/"
+          ssh ${SSH_OPTS} "${DEPLOY_USER}@${DEPLOY_HOST}" \
             "chmod +x '${DEPLOY_PATH}/deploy-prod.sh' && \
             DEPLOY_PATH='${DEPLOY_PATH}' GHCR_USERNAME='${GHCR_USERNAME}' GHCR_TOKEN='${GHCR_TOKEN}' \
             BACKEND_IMAGE='${BACKEND_IMAGE}' NGINX_IMAGE='${NGINX_IMAGE}' IMAGE_TAG='${IMAGE_TAG}' \


### PR DESCRIPTION
## Summary
- force `scp` to use legacy protocol (`-O`) in CD deploy step
- create `${DEPLOY_PATH}` on host before file transfer to avoid path-related copy failures
- keep strict host key checking and batch mode for deterministic SSH behavior

## Test plan
- [ ] Trigger CD workflow from this branch and verify deploy step passes `scp`
- [ ] Confirm production smoke health check succeeds


Made with [Cursor](https://cursor.com)