### PR TITLE
fix(cd): fix ssh option

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -110,7 +110,8 @@ jobs:
             echo "DEPLOY_PATH secret must be set (path to deploy folder on server)."
             exit 1
           fi
-          scp deploy/docker-compose.prod.yml deploy/scripts/deploy-prod.sh "${DEPLOY_USER}@${DEPLOY_HOST}:${DEPLOY_PATH}/"
+          ssh "${DEPLOY_USER}@${DEPLOY_HOST}" "mkdir -p '${DEPLOY_PATH}'"
+          scp -O deploy/docker-compose.prod.yml deploy/scripts/deploy-prod.sh "${DEPLOY_USER}@${DEPLOY_HOST}:${DEPLOY_PATH}/"
           ssh "${DEPLOY_USER}@${DEPLOY_HOST}" \
             "chmod +x '${DEPLOY_PATH}/deploy-prod.sh' && \
             DEPLOY_PATH='${DEPLOY_PATH}' GHCR_USERNAME='${GHCR_USERNAME}' GHCR_TOKEN='${GHCR_TOKEN}' \


### PR DESCRIPTION
## Summary
- ensure the remote deploy directory exists before uploading deploy assets
- use legacy SCP mode (`scp -O`) in CD to avoid OpenSSH/SFTP incompatibilities during transfer
- keep deployment script execution flow unchanged while improving transfer reliability

## Why
- production deploys can fail when the target path does not already exist
- some server/client SSH combinations require legacy SCP mode for successful file copy in GitHub Actions

## Test plan
- [ ] workflow syntax check via GitHub Actions
- [ ] run CD workflow on a test tag/commit and confirm `scp` transfer succeeds
- [ ] verify `deploy-prod.sh` runs and containers are updated on server

## Rollback notes
- revert this PR to restore previous SCP behavior and directory handling in CD

Made with [Cursor](https://cursor.com)