### PR TITLE
feat(frontend): enhance chatroom composer with textarea and scrollbar styles

### DIFF
--- a/frontend/src/features/chatroom/components/ChatroomScreen.tsx
+++ b/frontend/src/features/chatroom/components/ChatroomScreen.tsx
@@ -20,7 +20,7 @@ export default function ChatroomScreen({ chatroomId }: ChatroomScreenProps) {
   const { data: chatroom, isLoading: isChatroomLoading } = useChatroom(chatroomId)
   const { data: messages = [], isLoading: isMessagesLoading } = useMessages(chatroomId)
   const { isTyping, streamingContent } = useWebSocketStream(chatroomId)
-  const inputRef = useRef<HTMLInputElement>(null)
+  const inputRef = useRef<HTMLTextAreaElement>(null)
 
   const {
     inputValue,
@@ -128,10 +128,10 @@ export default function ChatroomScreen({ chatroomId }: ChatroomScreenProps) {
       </div>
 
       <div
-        className="p-4 bg-white border-t shrink-0 z-10"
+        className="px-3 sm:px-4 pt-3 pb-2 bg-white border-t shrink-0 z-10"
         style={{
           borderColor: 'var(--border-color)',
-          paddingBottom: 'calc(1rem + env(safe-area-inset-bottom, 0px))',
+          paddingBottom: 'calc(0.5rem + env(safe-area-inset-bottom, 0px))',
         }}
       >
         <Composer
@@ -142,8 +142,8 @@ export default function ChatroomScreen({ chatroomId }: ChatroomScreenProps) {
           onInputFocus={handleComposerFocus}
           onSubmit={(event) => handleSendMessage(event, inputRef)}
         />
-        <div className="text-center mt-2">
-          <span className="text-[10px] text-gray-400">
+        <div className="text-center mt-1.5 mb-0.5 px-4">
+          <span className="text-[11px] text-gray-400 leading-snug">
             Chatty can make mistakes. Consider verifying important information.
           </span>
         </div>

--- a/frontend/src/features/chatroom/components/Composer.test.tsx
+++ b/frontend/src/features/chatroom/components/Composer.test.tsx
@@ -7,7 +7,7 @@ describe('Composer', () => {
   it('disables submit button when input is blank', () => {
     render(
       <Composer
-        inputRef={createRef<HTMLInputElement>()}
+        inputRef={createRef<HTMLTextAreaElement>()}
         inputValue="   "
         isSendLocked={false}
         onInputChange={vi.fn()}
@@ -15,7 +15,7 @@ describe('Composer', () => {
       />,
     )
 
-    expect(screen.getByRole('button').hasAttribute('disabled')).toBe(true)
+    expect(screen.getByRole('button', { name: 'Send message' }).hasAttribute('disabled')).toBe(true)
   })
 
   it('calls callbacks for typing and submit', () => {
@@ -24,7 +24,7 @@ describe('Composer', () => {
 
     render(
       <Composer
-        inputRef={createRef<HTMLInputElement>()}
+        inputRef={createRef<HTMLTextAreaElement>()}
         inputValue="hello"
         isSendLocked={false}
         onInputChange={handleInputChange}
@@ -33,9 +33,23 @@ describe('Composer', () => {
     )
 
     fireEvent.change(screen.getByPlaceholderText('Message Chatty...'), { target: { value: 'new value' } })
-    fireEvent.submit(screen.getByRole('button').closest('form') as HTMLFormElement)
+    fireEvent.submit(screen.getByRole('button', { name: 'Send message' }).closest('form') as HTMLFormElement)
 
     expect(handleInputChange).toHaveBeenCalledWith('new value')
     expect(handleSubmit).toHaveBeenCalledTimes(1)
+  })
+
+  it('expands textarea rows up to 6 lines', () => {
+    render(
+      <Composer
+        inputRef={createRef<HTMLTextAreaElement>()}
+        inputValue={'1\n2\n3\n4\n5\n6\n7'}
+        isSendLocked={false}
+        onInputChange={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByPlaceholderText('Message Chatty...').getAttribute('rows')).toBe('6')
   })
 })

--- a/frontend/src/features/chatroom/components/Composer.tsx
+++ b/frontend/src/features/chatroom/components/Composer.tsx
@@ -1,6 +1,5 @@
-import { memo, type FormEvent, type RefObject } from 'react'
+import { memo, type FormEvent, type KeyboardEvent, type RefObject } from 'react'
 import { Send } from 'lucide-react'
-import Input from '../../../shared/ui/Input'
 import Button from '../../../shared/ui/Button'
 
 interface ComposerProps {
@@ -9,7 +8,7 @@ interface ComposerProps {
   onInputChange: (value: string) => void
   onSubmit: (e: FormEvent) => void
   onInputFocus?: () => void
-  inputRef: RefObject<HTMLInputElement | null>
+  inputRef: RefObject<HTMLTextAreaElement | null>
 }
 
 function ComposerComponent({
@@ -20,18 +19,32 @@ function ComposerComponent({
   onInputFocus,
   inputRef,
 }: ComposerProps) {
+  const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key !== 'Enter' || event.shiftKey) {
+      return
+    }
+
+    event.preventDefault()
+    event.currentTarget.form?.requestSubmit()
+  }
+
   return (
-    <form onSubmit={onSubmit} className="flex items-end gap-3 max-w-4xl mx-auto">
+    <form onSubmit={onSubmit} className="flex items-end gap-2 sm:gap-3 max-w-4xl mx-auto">
       <div className="flex-1">
-        <Input
-          ref={inputRef}
-          value={inputValue}
-          onChange={(e) => onInputChange(e.target.value)}
-          onFocus={onInputFocus}
-          placeholder="Message Chatty..."
-          className="rounded-full px-5 bg-gray-50 border-gray-200 focus:bg-white transition-colors h-11 text-base"
-          type="search"
-        />
+        <div className="rounded-3xl pr-2 border border-gray-200 bg-gray-50 transition-colors overflow-hidden focus-within:bg-white focus-within:ring-2 focus-within:ring-brand-500 focus-within:border-transparent">
+          <textarea
+            ref={inputRef}
+            value={inputValue}
+            onChange={(e) => onInputChange(e.target.value)}
+            onKeyDown={handleKeyDown}
+            onFocus={onInputFocus}
+            rows={1}
+            placeholder="Message Chatty..."
+            autoComplete="off"
+            spellCheck={false}
+            className="block w-full bg-transparent px-4 sm:px-5 py-2 text-base leading-6 placeholder:text-gray-400 focus:outline-none min-h-11 max-h-36 resize-none overflow-y-auto overflow-x-hidden [scrollbar-color:var(--scrollbar-thumb)_transparent] [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:border-2 [&::-webkit-scrollbar-thumb]:border-transparent"
+          />
+        </div>
       </div>
       <Button
         type="submit"

--- a/frontend/src/features/chatroom/components/Composer.tsx
+++ b/frontend/src/features/chatroom/components/Composer.tsx
@@ -19,6 +19,9 @@ function ComposerComponent({
   onInputFocus,
   inputRef,
 }: ComposerProps) {
+  const lineCount = inputValue.split('\n').length
+  const textareaRows = Math.min(Math.max(lineCount, 1), 6)
+
   const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
     if (event.key !== 'Enter' || event.shiftKey) {
       return
@@ -38,7 +41,7 @@ function ComposerComponent({
             onChange={(e) => onInputChange(e.target.value)}
             onKeyDown={handleKeyDown}
             onFocus={onInputFocus}
-            rows={1}
+            rows={textareaRows}
             placeholder="Message Chatty..."
             autoComplete="off"
             spellCheck={false}
@@ -50,6 +53,7 @@ function ComposerComponent({
         type="submit"
         className="rounded-full h-11 w-11 shrink-0 p-0 shadow-sm"
         disabled={!inputValue.trim() || isSendLocked}
+        aria-label="Send message"
       >
         <Send className="h-5 w-5" />
       </Button>

--- a/frontend/src/features/chatroom/hooks/useChatroomMessageComposer.test.tsx
+++ b/frontend/src/features/chatroom/hooks/useChatroomMessageComposer.test.tsx
@@ -45,9 +45,9 @@ describe('useChatroomMessageComposer', () => {
   })
 
   it('sends message payload and clears input', async () => {
-    const input = document.createElement('input')
-    const blurSpy = vi.spyOn(input, 'blur')
-    const inputRef = { current: input } as unknown as RefObject<HTMLInputElement | null>
+    const textarea = document.createElement('textarea')
+    const blurSpy = vi.spyOn(textarea, 'blur')
+    const inputRef = { current: textarea } as unknown as RefObject<HTMLTextAreaElement | null>
     const { result } = renderHook(() =>
       useChatroomMessageComposer({
         chatroomId: 12,

--- a/frontend/src/features/chatroom/hooks/useChatroomMessageComposer.ts
+++ b/frontend/src/features/chatroom/hooks/useChatroomMessageComposer.ts
@@ -48,7 +48,7 @@ export const useChatroomMessageComposer = ({
     }
   }, [displayMessages, isStreaming, isWaitingForResponse])
 
-  const handleSendMessage = (event: FormEvent, inputRef: RefObject<HTMLInputElement | null>) => {
+  const handleSendMessage = (event: FormEvent, inputRef: RefObject<HTMLTextAreaElement | null>) => {
     event.preventDefault()
     if (!inputValue.trim() || isSendLocked) return
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -35,6 +35,9 @@
     --bg-color: var(--color-surface-50);
     --text-color: var(--color-surface-900);
     --border-color: var(--color-surface-100);
+    --scrollbar-track: #00000000;
+    --scrollbar-thumb: #cbd5e1;
+    --scrollbar-thumb-hover: #94a3b8;
     color-scheme: light;
   }
 
@@ -58,5 +61,29 @@
     height: 100%;
     min-height: 0;
     overflow: hidden;
+  }
+
+  * {
+    scrollbar-width: thin;
+    scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
+  }
+
+  *::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+
+  *::-webkit-scrollbar-track {
+    background: var(--scrollbar-track);
+  }
+
+  *::-webkit-scrollbar-thumb {
+    background: var(--scrollbar-thumb);
+    border-radius: 9999px;
+    border: 2px solid var(--scrollbar-track);
+  }
+
+  *::-webkit-scrollbar-thumb:hover {
+    background: var(--scrollbar-thumb-hover);
   }
 }

--- a/frontend/src/layout/DefaultLayout.test.tsx
+++ b/frontend/src/layout/DefaultLayout.test.tsx
@@ -95,7 +95,7 @@ describe('DefaultLayout', () => {
 
     render(<DefaultLayout />)
 
-    expect(screen.getByText('sha:1a2b3c4 • built:2026-04-23 12:34:56 UTC')).toBeTruthy()
+    expect(screen.getByText('1a2b3c4 • 2026-04-23 12:34:56')).toBeTruthy()
   })
 
   it('hides release metadata when release env variables are missing', async () => {

--- a/frontend/src/layout/DefaultLayout.tsx
+++ b/frontend/src/layout/DefaultLayout.tsx
@@ -20,7 +20,7 @@ function formatReleaseBuiltAt(value: string): string {
     return value
   }
 
-  return parsed.toISOString().replace('T', ' ').replace('.000Z', ' UTC')
+  return parsed.toISOString().replace('T', ' ').replace('.000Z', '')
 }
 
 export default function DefaultLayout() {
@@ -30,10 +30,7 @@ export default function DefaultLayout() {
   const toggleSidebar = useUIStore((state) => state.toggleSidebar)
   const setSidebarOpen = useUIStore((state) => state.setSidebarOpen)
   const formattedBuiltAt = releaseBuiltAtValue ? formatReleaseBuiltAt(releaseBuiltAtValue) : null
-  const releaseLabel =
-    releaseSha && formattedBuiltAt
-      ? `sha:${releaseSha} • built:${formattedBuiltAt}`
-      : null
+  const releaseLabel = releaseSha && formattedBuiltAt ? `${releaseSha} • ${formattedBuiltAt}` : null
 
   useEffect(() => {
     if (!popup) return
@@ -108,31 +105,36 @@ export default function DefaultLayout() {
       <div className="flex flex-1 flex-col min-h-0 overflow-hidden relative w-full">
         {/* Header */}
         <header
-          className="h-16 flex items-center justify-between px-4 md:px-6 border-b shrink-0 gap-4 bg-white z-30"
+          className="h-14 md:h-16 flex items-center justify-between px-3 sm:px-4 md:px-6 border-b shrink-0 gap-3 bg-white z-30"
           style={{ borderColor: 'var(--border-color)' }}
         >
-          <div className="flex items-center gap-4">
+          <div className="flex items-center gap-2 sm:gap-3 min-w-0">
             <div className="md:hidden">
-              <Button variant="ghost" size="icon" onClick={toggleSidebar}>
+              <Button variant="ghost" size="icon" onClick={toggleSidebar} className="h-9 w-9">
                 <Menu className="h-6 w-6" />
               </Button>
             </div>
             <Link
               to={ROUTES.HOME}
-              className="flex items-center gap-2 hover:opacity-80 transition-opacity"
+              className="flex items-center gap-2 hover:opacity-80 transition-opacity min-w-0"
             >
               <img
                 src="/icon.svg"
                 alt=""
-                className="w-8 h-8 shrink-0 rounded-lg"
+                className="w-7 h-7 md:w-8 md:h-8 shrink-0 rounded-lg"
                 width={32}
                 height={32}
                 aria-hidden
               />
-              <div className="flex flex-col">
-                <h1 className="font-bold tracking-tight text-xl text-gray-900 leading-tight">Chatty</h1>
+              <div className="flex flex-col min-w-0">
+                <h1 className="font-bold tracking-tight text-lg md:text-xl text-gray-900 leading-tight truncate">
+                  Chatty
+                </h1>
                 {releaseLabel ? (
-                  <span className="text-[10px] text-gray-500 leading-tight">{releaseLabel}</span>
+                  <span className="text-[10px] text-gray-500 leading-tight truncate" title={releaseLabel}>
+                    <span className="sm:hidden">{releaseSha}</span>
+                    <span className="hidden sm:inline">{releaseLabel}</span>
+                  </span>
                 ) : null}
               </div>
             </Link>

--- a/frontend/src/shared/ui/GithubLink.tsx
+++ b/frontend/src/shared/ui/GithubLink.tsx
@@ -13,7 +13,7 @@ const SIZE_STYLES = {
   },
   medium: {
     wrapper:
-      'inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 text-sm text-gray-500 hover:text-gray-700 hover:bg-gray-100',
+      'inline-flex items-center gap-1.5 rounded-md px-2 py-1 md:px-2.5 text-sm text-gray-500 hover:text-gray-700 hover:bg-gray-100',
     icon: 'h-4 w-4',
   },
 } as const
@@ -28,9 +28,10 @@ export default function GithubLink({ size = 'small', className = '' }: GithubLin
       rel="noreferrer"
       className={`${style.wrapper} transition-colors ${className}`.trim()}
       aria-label="Visit wndgur2 GitHub profile"
+      title="wndgur2 on GitHub"
     >
       <img src={githubLogo} alt="" className={style.icon} aria-hidden="true" />
-      <span>wndgur2</span>
+      <span className={size === 'medium' ? 'hidden sm:inline' : ''}>wndgur2</span>
     </a>
   )
 }


### PR DESCRIPTION
## Summary
- replace the composer input with an auto-growing textarea to improve long-message composition
- polish composer and layout styling, including custom scrollbar treatment and updated shell spacing
- align chatroom composer tests/hooks with the updated input behavior

## Why
- the previous single-line input made longer messages harder to compose and reduced readability while typing

## Test plan
- [ ] frontend: `npm run lint`
- [ ] frontend: `npm run typecheck`
- [ ] frontend: `npm run test`

## Rollback notes
- revert this PR to restore the previous single-line composer behavior and prior layout styling

Made with [Cursor](https://cursor.com)