### PR TITLE
feat(backend): add ai_message_metadata and backend unit tests

### DIFF
--- a/.cursor/references/PROJECT_PROPOSAL.md
+++ b/.cursor/references/PROJECT_PROPOSAL.md
@@ -25,12 +25,12 @@ The system allows AI to send messages to users without waiting for user input, b
 - Stream AI responses in real time.
 - Maintain continuous message flow during generation.
 
-#### 3.1.2 Voluntary AI Messaging
+#### 3.1.2 Proactive AI Messaging
 
 - Trigger AI messages without user input using a slow-start scheduling algorithm:
   - Initializes a 4-second delay after the last message.
   - At the scheduled time, a lightweight "Evaluator" model decides whether to initiate a message.
-  - If yes, initiates the voluntary message. If no, the delay time is doubled for the next check.
+  - If yes, initiates a proactive message. If no, the delay time is doubled for the next check.
 - Use chatroom context for message generation.
 
 #### 3.1.3 Chatrooms
@@ -58,9 +58,16 @@ The system allows AI to send messages to users without waiting for user input, b
 
 #### 3.2.4 Notifications
 
-- Receive push notifications indicating voluntary AI messages using Firebase Cloud Messaging (FCM).
+- Receive push notifications indicating proactive AI messages using Firebase Cloud Messaging (FCM).
 
-#### 3.2.5 Cloning/branching Chatroom
+#### 3.2.5 AI Message Metadata
+
+- Store explainability and delivery metadata for AI-authored messages in a dedicated 1:1 metadata record.
+- Track read state using `read_at` (nullable datetime) instead of a boolean.
+- Track AI delivery type using `delivery_mode` (`reply` or `proactive`).
+- Store trigger diagnostics with `trigger_reason` and optional JSON `trigger_context`.
+
+#### 3.2.6 Cloning/branching Chatroom
 
 - Create a new chatroom from an existing one.
 - Clone: Copy configuration(prompt, profile-image) only.

--- a/.cursor/references/SCHEMA.md
+++ b/.cursor/references/SCHEMA.md
@@ -9,6 +9,7 @@ erDiagram
     users ||--o{ user_devices : "has"
     users ||--o{ chatrooms : "owns"
     chatrooms ||--o{ messages : "contains"
+    messages ||--|| ai_message_metadata : "has metadata"
 
     users {
         bigint id PK
@@ -42,6 +43,16 @@ erDiagram
         enum sender "'user', 'ai'"
         longtext content
         timestamp created_at
+    }
+
+    ai_message_metadata {
+        bigint message_id PK, FK
+        datetime read_at "NULL until read"
+        enum delivery_mode "'reply', 'proactive'"
+        varchar trigger_reason
+        json trigger_context "NULL optional explainability context"
+        timestamp created_at
+        timestamp updated_at
     }
 ```
 
@@ -111,11 +122,30 @@ CREATE TABLE IF NOT EXISTS messages (
         REFERENCES chatrooms(id)
         ON DELETE CASCADE
 );
+
+-- -----------------------------------------------------
+-- Table `ai_message_metadata`
+-- 1:1 metadata for AI-authored messages only.
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS ai_message_metadata (
+    message_id BIGINT PRIMARY KEY,
+    read_at DATETIME NULL,
+    delivery_mode ENUM('reply', 'proactive') NOT NULL,
+    trigger_reason VARCHAR(255) NOT NULL,
+    trigger_context JSON NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_ai_message_metadata_message_id
+        FOREIGN KEY (message_id)
+        REFERENCES messages(id)
+        ON DELETE CASCADE
+);
 ```
 
 ## 3. Agentic Implementation Notes
 
 - **Primary Keys:** Standardized as auto-incrementing `BIGINT`. Adjust to UUID/ULID if the architecture demands decentralization, but `BIGINT` provides better indexing performance for MySQL.
-- **Voluntary AI Messaging Logic:** The `chatrooms` table holds `current_delay_seconds` and `next_evaluation_time`. DB default is `60`, and app logic resets it to `4` after a user message, then computes `next_evaluation_time`. If the scheduled evaluation fails (decides not to send), multiply `current_delay_seconds` by 2 and recalculate `next_evaluation_time`.
+- **Proactive AI Messaging Logic:** The `chatrooms` table holds `current_delay_seconds` and `next_evaluation_time`. DB default is `60`, and app logic resets it to `4` after a user message, then computes `next_evaluation_time`. If the scheduled evaluation fails (decides not to send), multiply `current_delay_seconds` by 2 and recalculate `next_evaluation_time`.
+- **AI Message Metadata Invariant:** `ai_message_metadata` rows are created only when `messages.sender = 'ai'` and are always 1:1 keyed by `message_id`.
 - **Image Uploads:** `profile_image_url` on `chatrooms` holds the CDN/S3 URL indicating the reference after the Blob upload is resolved by the backend.
 - **Constraints:** Foreign key cascading removes orphaned tokens, chatrooms, and messages when a parent entity is deleted.

--- a/.cursor/skills/api-development/references/API_DOCUMENTATION.md
+++ b/.cursor/skills/api-development/references/API_DOCUMENTATION.md
@@ -212,6 +212,12 @@ Create a new chatroom from an existing one, copying BOTH the configuration and t
 
 ## 3. Messaging
 
+### 3.0 Backend Storage Note (No Contract Change)
+
+- AI-authored messages are persisted with an internal 1:1 metadata record in `ai_message_metadata`.
+- This metadata currently includes `read_at`, `delivery_mode` (`reply` or `proactive`), `trigger_reason`, and optional `trigger_context`.
+- This is internal persistence only for now: REST and Socket.IO payload schemas in this document remain unchanged.
+
 ### 3.1 Retrieve Message History
 
 Retrieve the message history for a specific chatroom.
@@ -275,7 +281,7 @@ Send a message from the user to the AI. _(Note: Responses are streamed via WebSo
 
 ### 4.1 Register FCM Device Token
 
-Register a user's device for receiving FCM push notifications (for voluntary AI messages).
+Register a user's device for receiving FCM push notifications (for proactive AI messages).
 
 - **Method:** `POST`
 - **URL:** `/api/notifications/register`

--- a/.cursor/skills/nestjs-development/SKILL.md
+++ b/.cursor/skills/nestjs-development/SKILL.md
@@ -12,8 +12,8 @@ Apply this skill for backend implementation and refactors in `backend/` that use
 ## Source of truth
 
 - Use `../api-development/references/API_DOCUMENTATION.md` for API and Socket.IO contracts.
-- Use `references/PROJECT_PROPOSAL.md` for feature intent and scope.
-- Use `references/SCHEMA.md` for data model constraints and storage behavior.
+- Use `../../references/PROJECT_PROPOSAL.md` for feature intent and scope.
+- Use `../../references/SCHEMA.md` for data model constraints and storage behavior.
 
 ## Engineering defaults
 

--- a/README.md
+++ b/README.md
@@ -71,10 +71,9 @@ Important Socket.IO events include:
 
 ## Documentation Index
 
-- Product proposal: `.cursor/skills/nestjs-development/references/PROJECT_PROPOSAL.md`
+- Product proposal: `.cursor/references/PROJECT_PROPOSAL.md`
 - API contract: `.cursor/skills/api-development/references/API_DOCUMENTATION.md`
-- Data model: `.cursor/skills/nestjs-development/references/SCHEMA.md`
-- Frontend testing guide: `contexts/FRONTEND_TESTING.md`
+- Data model: `.cursor/references/SCHEMA.md`
 - Backend guide: `backend/README.md`
 - Frontend guide: `frontend/README.md`
 - Deployment guide: `deploy/README.md`

--- a/backend/eslint.config.mjs
+++ b/backend/eslint.config.mjs
@@ -6,7 +6,12 @@ import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
   {
-    ignores: ['eslint.config.mjs'],
+    ignores: [
+      'eslint.config.mjs',
+      'dist/**',
+      'coverage/**',
+      'node_modules/**',
+    ],
   },
   eslint.configs.recommended,
   ...tseslint.configs.recommendedTypeChecked,

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,13 +6,14 @@
   "private": true,
   "license": "UNLICENSED",
   "scripts": {
+    "postinstall": "prisma generate",
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
     "dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
-    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+    "lint": "eslint .",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
@@ -90,6 +91,11 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
+    "coverageReporters": [
+      "text",
+      "html",
+      "lcov"
+    ],
     "testEnvironment": "node"
   }
 }

--- a/backend/prisma/migrations/20260424000100_add_ai_message_metadata/migration.sql
+++ b/backend/prisma/migrations/20260424000100_add_ai_message_metadata/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE `ai_message_metadata` (
+    `message_id` BIGINT NOT NULL,
+    `read_at` DATETIME(3) NULL,
+    `delivery_mode` ENUM('reply', 'proactive') NOT NULL,
+    `trigger_reason` VARCHAR(255) NOT NULL,
+    `trigger_context` JSON NULL,
+    `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updated_at` DATETIME(3) NOT NULL,
+
+    PRIMARY KEY (`message_id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `ai_message_metadata` ADD CONSTRAINT `ai_message_metadata_message_id_fkey` FOREIGN KEY (`message_id`) REFERENCES `messages`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -52,6 +52,11 @@ enum Sender {
   ai
 }
 
+enum AiMessageDeliveryMode {
+  reply
+  proactive
+}
+
 model Message {
   id         BigInt   @id @default(autoincrement())
   chatroomId BigInt   @map("chatroom_id")
@@ -59,7 +64,22 @@ model Message {
   content    String   @db.LongText
   createdAt  DateTime @default(now()) @map("created_at")
 
-  chatroom Chatroom @relation(fields: [chatroomId], references: [id], onDelete: Cascade)
+  chatroom          Chatroom           @relation(fields: [chatroomId], references: [id], onDelete: Cascade)
+  aiMessageMetadata AiMessageMetadata?
 
   @@map("messages")
+}
+
+model AiMessageMetadata {
+  messageId      BigInt                @id @map("message_id")
+  readAt         DateTime?             @map("read_at")
+  deliveryMode   AiMessageDeliveryMode @map("delivery_mode")
+  triggerReason  String                @map("trigger_reason") @db.VarChar(255)
+  triggerContext Json?                 @map("trigger_context")
+  createdAt      DateTime              @default(now()) @map("created_at")
+  updatedAt      DateTime              @updatedAt @map("updated_at")
+
+  message Message @relation(fields: [messageId], references: [id], onDelete: Cascade)
+
+  @@map("ai_message_metadata")
 }

--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -1,0 +1,42 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import { LoginDto } from './dto/login.dto';
+
+describe('AuthController', () => {
+  let controller: AuthController;
+  const mockAuthService = {
+    login: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AuthController],
+      providers: [{ provide: AuthService, useValue: mockAuthService }],
+    }).compile();
+
+    controller = module.get<AuthController>(AuthController);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('should delegate login to AuthService', async () => {
+    const dto: LoginDto = { username: 'alice' };
+    const payload = {
+      accessToken: 't',
+      user: { id: '1', username: 'alice' },
+    };
+    mockAuthService.login.mockResolvedValue(payload);
+
+    const result = await controller.login(dto);
+
+    expect(mockAuthService.login).toHaveBeenCalledWith(dto);
+    expect(result).toEqual(payload);
+  });
+});

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -1,0 +1,82 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { JwtService } from '@nestjs/jwt';
+import { AuthService } from './auth.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { LoginDto } from './dto/login.dto';
+
+describe('AuthService', () => {
+  let service: AuthService;
+  const mockPrisma = {
+    user: {
+      findUnique: jest.fn(),
+      create: jest.fn(),
+    },
+  };
+  const mockJwtService = {
+    signAsync: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuthService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: JwtService, useValue: mockJwtService },
+      ],
+    }).compile();
+
+    service = module.get<AuthService>(AuthService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should login existing user and return token and user', async () => {
+    const dto: LoginDto = { username: 'alice' };
+    const user = { id: 42n, username: 'alice' };
+    mockPrisma.user.findUnique.mockResolvedValue(user);
+    mockJwtService.signAsync.mockResolvedValue('jwt-token');
+
+    const result = await service.login(dto);
+
+    expect(mockPrisma.user.findUnique).toHaveBeenCalledWith({
+      where: { username: 'alice' },
+    });
+    expect(mockPrisma.user.create).not.toHaveBeenCalled();
+    expect(mockJwtService.signAsync).toHaveBeenCalledWith({
+      sub: '42',
+      username: 'alice',
+    });
+    expect(result).toEqual({
+      accessToken: 'jwt-token',
+      user: { id: '42', username: 'alice' },
+    });
+  });
+
+  it('should create user when missing then return token and user', async () => {
+    const dto: LoginDto = { username: 'bob' };
+    const created = { id: 7n, username: 'bob' };
+    mockPrisma.user.findUnique.mockResolvedValue(null);
+    mockPrisma.user.create.mockResolvedValue(created);
+    mockJwtService.signAsync.mockResolvedValue('new-jwt');
+
+    const result = await service.login(dto);
+
+    expect(mockPrisma.user.create).toHaveBeenCalledWith({
+      data: { username: 'bob' },
+    });
+    expect(mockJwtService.signAsync).toHaveBeenCalledWith({
+      sub: '7',
+      username: 'bob',
+    });
+    expect(result).toEqual({
+      accessToken: 'new-jwt',
+      user: { id: '7', username: 'bob' },
+    });
+  });
+});

--- a/backend/src/auth/jwt-auth.guard.spec.ts
+++ b/backend/src/auth/jwt-auth.guard.spec.ts
@@ -1,0 +1,47 @@
+import { ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { JwtAuthGuard } from './jwt-auth.guard';
+
+describe('JwtAuthGuard', () => {
+  let reflector: { getAllAndOverride: jest.Mock };
+  let parentCanActivate: jest.SpyInstance;
+
+  function makeContext(): ExecutionContext {
+    return {
+      getHandler: () => function handler() {},
+      getClass: () => class TestClass {},
+    } as unknown as ExecutionContext;
+  }
+
+  beforeEach(() => {
+    reflector = { getAllAndOverride: jest.fn() };
+    const parentProto = Object.getPrototypeOf(JwtAuthGuard.prototype) as {
+      canActivate: (...args: unknown[]) => unknown;
+    };
+    parentCanActivate = jest
+      .spyOn(parentProto, 'canActivate')
+      .mockReturnValue(Promise.resolve(true));
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('allows public routes without invoking passport', () => {
+    reflector.getAllAndOverride.mockReturnValue(true);
+    const guard = new JwtAuthGuard(reflector as unknown as Reflector);
+    const ctx = makeContext();
+
+    expect(guard.canActivate(ctx)).toBe(true);
+    expect(parentCanActivate).not.toHaveBeenCalled();
+  });
+
+  it('delegates to passport for protected routes', () => {
+    reflector.getAllAndOverride.mockReturnValue(false);
+    const guard = new JwtAuthGuard(reflector as unknown as Reflector);
+
+    void guard.canActivate(makeContext());
+
+    expect(parentCanActivate).toHaveBeenCalled();
+  });
+});

--- a/backend/src/auth/jwt.strategy.spec.ts
+++ b/backend/src/auth/jwt.strategy.spec.ts
@@ -1,0 +1,15 @@
+import { JwtStrategy } from './jwt.strategy';
+
+describe('JwtStrategy', () => {
+  let strategy: JwtStrategy;
+
+  beforeEach(() => {
+    strategy = new JwtStrategy();
+  });
+
+  it('should map payload.sub to userId', () => {
+    expect(strategy.validate({ sub: 'user-123' })).toEqual({
+      userId: 'user-123',
+    });
+  });
+});

--- a/backend/src/chatrooms/chatrooms.repository.spec.ts
+++ b/backend/src/chatrooms/chatrooms.repository.spec.ts
@@ -1,0 +1,82 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ChatroomsRepository } from './chatrooms.repository';
+import { PrismaService } from '../prisma/prisma.service';
+
+describe('ChatroomsRepository', () => {
+  let repository: ChatroomsRepository;
+  const mockPrisma = {
+    chatroom: {
+      findMany: jest.fn(),
+      findFirst: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+    $transaction: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ChatroomsRepository,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+
+    repository = module.get<ChatroomsRepository>(ChatroomsRepository);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(repository).toBeDefined();
+  });
+
+  it('findManyByUser queries by userId', async () => {
+    mockPrisma.chatroom.findMany.mockResolvedValue([]);
+    await repository.findManyByUser(3n);
+    expect(mockPrisma.chatroom.findMany).toHaveBeenCalledWith({
+      where: { userId: 3n },
+    });
+  });
+
+  it('findByIdAndUser queries id and userId', async () => {
+    await repository.findByIdAndUser(1n, 2n);
+    expect(mockPrisma.chatroom.findFirst).toHaveBeenCalledWith({
+      where: { id: 1n, userId: 2n },
+    });
+  });
+
+  it('create forwards data to prisma', async () => {
+    const data = { name: 'Room', user: { connect: { id: 1n } } };
+    await repository.create(data as never);
+    expect(mockPrisma.chatroom.create).toHaveBeenCalledWith({ data });
+  });
+
+  it('update forwards id and data', async () => {
+    await repository.update(5n, { name: 'X' });
+    expect(mockPrisma.chatroom.update).toHaveBeenCalledWith({
+      where: { id: 5n },
+      data: { name: 'X' },
+    });
+  });
+
+  it('delete forwards id', async () => {
+    await repository.delete(9n);
+    expect(mockPrisma.chatroom.delete).toHaveBeenCalledWith({
+      where: { id: 9n },
+    });
+  });
+
+  it('transaction forwards callback to $transaction', async () => {
+    const fn = (): Promise<string> => Promise.resolve('ok');
+    mockPrisma.$transaction.mockImplementation(
+      (cb: (tx: unknown) => Promise<string>) => cb({} as never),
+    );
+    const result = await repository.transaction(fn);
+    expect(mockPrisma.$transaction).toHaveBeenCalledWith(fn);
+    expect(result).toBe('ok');
+  });
+});

--- a/backend/src/common/filters/http-exception.filter.spec.ts
+++ b/backend/src/common/filters/http-exception.filter.spec.ts
@@ -1,0 +1,109 @@
+import { ArgumentsHost, HttpException, HttpStatus } from '@nestjs/common';
+import { Request, Response } from 'express';
+import { HttpExceptionFilter } from './http-exception.filter';
+
+describe('HttpExceptionFilter', () => {
+  const filter = new HttpExceptionFilter();
+
+  function createHost(
+    request: Partial<Request>,
+    response: Partial<Response>,
+  ): ArgumentsHost {
+    return {
+      switchToHttp: () => ({
+        getResponse: () => response as Response,
+        getRequest: () => request as Request,
+      }),
+    } as ArgumentsHost;
+  }
+
+  it('maps HttpException with string body to status and message', () => {
+    const json = jest.fn();
+    const status = jest.fn().mockReturnValue({ json });
+    const host = createHost(
+      { url: '/api/test' },
+      { status: status as unknown as Response['status'] },
+    );
+
+    filter.catch(new HttpException('Bad', HttpStatus.BAD_REQUEST), host);
+
+    expect(status).toHaveBeenCalledWith(400);
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        statusCode: 400,
+        path: '/api/test',
+        message: 'Bad',
+      }),
+    );
+    const rawCalls = json.mock.calls as unknown as Array<
+      [{ timestamp: string }]
+    >;
+    const firstPayload = rawCalls[0][0];
+    expect(firstPayload.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('maps HttpException with object message', () => {
+    const json = jest.fn();
+    const status = jest.fn().mockReturnValue({ json });
+    const host = createHost(
+      { url: '/x' },
+      { status: status as unknown as Response['status'] },
+    );
+
+    filter.catch(
+      new HttpException(
+        { message: ['a', 'b'] },
+        HttpStatus.UNPROCESSABLE_ENTITY,
+      ),
+      host,
+    );
+
+    expect(status).toHaveBeenCalledWith(422);
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        statusCode: 422,
+        message: ['a', 'b'],
+      }),
+    );
+  });
+
+  it('uses Unexpected error when HttpException object omits message', () => {
+    const json = jest.fn();
+    const status = jest.fn().mockReturnValue({ json });
+    const host = createHost(
+      { url: '/y' },
+      { status: status as unknown as Response['status'] },
+    );
+
+    filter.catch(
+      new HttpException({ message: undefined }, HttpStatus.BAD_REQUEST),
+      host,
+    );
+
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        statusCode: 400,
+        message: 'Unexpected error',
+      }),
+    );
+  });
+
+  it('returns 500 and default message for unknown errors', () => {
+    const json = jest.fn();
+    const status = jest.fn().mockReturnValue({ json });
+    const host = createHost(
+      { url: '/fail' },
+      { status: status as unknown as Response['status'] },
+    );
+
+    filter.catch(new Error('boom'), host);
+
+    expect(status).toHaveBeenCalledWith(500);
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        statusCode: 500,
+        message: 'Unexpected error',
+      }),
+    );
+  });
+});

--- a/backend/src/common/interceptors/bigint-serializer.interceptor.spec.ts
+++ b/backend/src/common/interceptors/bigint-serializer.interceptor.spec.ts
@@ -1,0 +1,44 @@
+import { of } from 'rxjs';
+import { lastValueFrom } from 'rxjs';
+import { ExecutionContext } from '@nestjs/common';
+import { BigIntSerializerInterceptor } from './bigint-serializer.interceptor';
+
+describe('BigIntSerializerInterceptor', () => {
+  const interceptor = new BigIntSerializerInterceptor();
+  const noopContext = {} as ExecutionContext;
+
+  async function serializeThrough(data: unknown): Promise<unknown> {
+    const obs = interceptor.intercept(noopContext, {
+      handle: () => of(data),
+    });
+    return lastValueFrom(obs);
+  }
+
+  it('stringifies bigint', async () => {
+    await expect(serializeThrough(10n)).resolves.toBe('10');
+  });
+
+  it('passes Date through unchanged', async () => {
+    const d = new Date('2020-01-01T00:00:00.000Z');
+    await expect(serializeThrough(d)).resolves.toBe(d);
+  });
+
+  it('serializes nested objects and arrays', async () => {
+    const input = {
+      id: 1n,
+      tags: [2n, { nested: 3n }],
+      empty: null,
+    };
+    await expect(serializeThrough(input)).resolves.toEqual({
+      id: '1',
+      tags: ['2', { nested: '3' }],
+      empty: null,
+    });
+  });
+
+  it('returns primitives as-is', async () => {
+    await expect(serializeThrough('x')).resolves.toBe('x');
+    await expect(serializeThrough(1)).resolves.toBe(1);
+    await expect(serializeThrough(true)).resolves.toBe(true);
+  });
+});

--- a/backend/src/common/utils/assets-path.util.spec.ts
+++ b/backend/src/common/utils/assets-path.util.spec.ts
@@ -1,0 +1,19 @@
+import { join, resolve } from 'path';
+import { resolveAssetsDir } from './assets-path.util';
+
+describe('resolveAssetsDir', () => {
+  const cwd = process.cwd();
+
+  it('defaults to src/assets under cwd when unset', () => {
+    expect(resolveAssetsDir()).toBe(join(cwd, 'src', 'assets'));
+  });
+
+  it('joins relative path to cwd', () => {
+    expect(resolveAssetsDir('var/uploads')).toBe(join(cwd, 'var/uploads'));
+  });
+
+  it('returns absolute path unchanged', () => {
+    const abs = resolve('/tmp/chatty-assets');
+    expect(resolveAssetsDir(abs)).toBe(abs);
+  });
+});

--- a/backend/src/infrastructure/storage/storage.service.spec.ts
+++ b/backend/src/infrastructure/storage/storage.service.spec.ts
@@ -1,0 +1,86 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import * as fs from 'fs';
+import { StorageService } from './storage.service';
+
+jest.mock('fs', () => {
+  const actual = jest.requireActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    existsSync: jest.fn(),
+    promises: {
+      ...actual.promises,
+      mkdir: jest.fn().mockResolvedValue(undefined),
+      writeFile: jest.fn().mockResolvedValue(undefined),
+    },
+  };
+});
+
+const mockedFs = fs as jest.Mocked<typeof import('fs')> & {
+  existsSync: jest.Mock;
+  promises: typeof fs.promises & {
+    mkdir: jest.Mock;
+    writeFile: jest.Mock;
+  };
+};
+
+describe('StorageService', () => {
+  let service: StorageService;
+  const mockConfig = { get: jest.fn() };
+
+  beforeEach(async () => {
+    mockedFs.existsSync.mockReturnValue(true);
+    mockedFs.promises.mkdir.mockClear();
+    mockedFs.promises.writeFile.mockClear();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        StorageService,
+        { provide: ConfigService, useValue: mockConfig },
+      ],
+    }).compile();
+
+    service = module.get<StorageService>(StorageService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('creates assets dir when missing then writes file and returns URL', async () => {
+    mockConfig.get.mockReturnValue(undefined);
+    mockedFs.existsSync.mockReturnValue(false);
+
+    const url = await service.saveProfileImage(
+      {
+        originalname: 'pic.png',
+        buffer: Buffer.from('x'),
+      } as Express.Multer.File,
+      'http://localhost:3000',
+    );
+
+    expect(mockedFs.promises.mkdir).toHaveBeenCalled();
+    expect(mockedFs.promises.writeFile).toHaveBeenCalled();
+    const writeCalls = mockedFs.promises.writeFile.mock
+      .calls as unknown as Array<[string, Buffer]>;
+    const writePath = writeCalls[0][0];
+    expect(writePath).toMatch(/pic\.png$/);
+    expect(url).toMatch(/^http:\/\/localhost:3000\/assets\/\d+-pic\.png$/);
+  });
+
+  it('skips mkdir when assets dir already exists', async () => {
+    mockConfig.get.mockReturnValue(undefined);
+    mockedFs.existsSync.mockReturnValue(true);
+
+    await service.saveProfileImage(
+      {
+        originalname: 'a.jpg',
+        buffer: Buffer.from(''),
+      } as Express.Multer.File,
+      'https://api.example.com',
+    );
+
+    expect(mockedFs.promises.mkdir).not.toHaveBeenCalled();
+    expect(mockedFs.promises.writeFile).toHaveBeenCalled();
+  });
+});

--- a/backend/src/messages/ai-response.service.spec.ts
+++ b/backend/src/messages/ai-response.service.spec.ts
@@ -1,0 +1,70 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AiResponseService } from './ai-response.service';
+import { OllamaService } from '../ollama/ollama.service';
+
+function* mockStream(chunks: { message?: { content?: string } }[]) {
+  for (const c of chunks) {
+    yield c;
+  }
+}
+
+describe('AiResponseService', () => {
+  let service: AiResponseService;
+  const mockOllama = {
+    streamChatResponse: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AiResponseService,
+        { provide: OllamaService, useValue: mockOllama },
+      ],
+    }).compile();
+
+    service = module.get<AiResponseService>(AiResponseService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('concatenates streamed chunks and invokes onChunk', async () => {
+    mockOllama.streamChatResponse.mockResolvedValue(
+      mockStream([
+        { message: { content: 'hel' } },
+        { message: { content: 'lo' } },
+        { message: { content: '' } },
+        { message: {} },
+      ]),
+    );
+    const onChunk = jest.fn();
+
+    const full = await service.generate(
+      [{ role: 'user', content: 'hi' }],
+      'sys',
+      onChunk,
+    );
+
+    expect(full).toBe('hello');
+    expect(onChunk).toHaveBeenCalledWith('hel');
+    expect(onChunk).toHaveBeenCalledWith('lo');
+    expect(mockOllama.streamChatResponse).toHaveBeenCalledWith(
+      [{ role: 'user', content: 'hi' }],
+      'sys',
+      undefined,
+    );
+  });
+
+  it('passes voluntary option to ollama', async () => {
+    mockOllama.streamChatResponse.mockResolvedValue(
+      mockStream([{ message: { content: 'x' } }]),
+    );
+
+    await service.generate([], 'prompt', undefined, { voluntary: true });
+
+    expect(mockOllama.streamChatResponse).toHaveBeenCalledWith([], 'prompt', {
+      voluntary: true,
+    });
+  });
+});

--- a/backend/src/messages/chatroom-state.repository.spec.ts
+++ b/backend/src/messages/chatroom-state.repository.spec.ts
@@ -1,0 +1,79 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ChatroomStateRepository } from './chatroom-state.repository';
+import { PrismaService } from '../prisma/prisma.service';
+import { INITIAL_AI_EVALUATION_DELAY_SECONDS } from '../ai-evaluation.constants';
+
+describe('ChatroomStateRepository', () => {
+  let repository: ChatroomStateRepository;
+  const mockPrisma = {
+    chatroom: {
+      findUnique: jest.fn(),
+      findFirst: jest.fn(),
+      update: jest.fn(),
+    },
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ChatroomStateRepository,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+
+    repository = module.get<ChatroomStateRepository>(ChatroomStateRepository);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('findById queries chatroom by id', async () => {
+    await repository.findById(8n);
+    expect(mockPrisma.chatroom.findUnique).toHaveBeenCalledWith({
+      where: { id: 8n },
+    });
+  });
+
+  it('findByIdAndUser queries id and userId', async () => {
+    await repository.findByIdAndUser(1n, 2n);
+    expect(mockPrisma.chatroom.findFirst).toHaveBeenCalledWith({
+      where: { id: 1n, userId: 2n },
+    });
+  });
+
+  it('clearNextEvaluationTime nulls nextEvaluationTime', async () => {
+    await repository.clearNextEvaluationTime(3n);
+    expect(mockPrisma.chatroom.update).toHaveBeenCalledWith({
+      where: { id: 3n },
+      data: { nextEvaluationTime: null },
+    });
+  });
+
+  it('resetDelay sets initial delay and future nextEvaluationTime', async () => {
+    const before = Date.now();
+    await repository.resetDelay(4n);
+    const after = Date.now();
+
+    const updateCalls = mockPrisma.chatroom.update.mock
+      .calls as unknown as Array<
+      [
+        {
+          where: { id: bigint };
+          data: { currentDelaySeconds: number; nextEvaluationTime: Date };
+        },
+      ]
+    >;
+    const updateArg = updateCalls[0][0];
+    expect(updateArg.where).toEqual({ id: 4n });
+    expect(updateArg.data.currentDelaySeconds).toBe(
+      INITIAL_AI_EVALUATION_DELAY_SECONDS,
+    );
+    const next = updateArg.data.nextEvaluationTime;
+    expect(next).toBeInstanceOf(Date);
+    const minExpected = before + INITIAL_AI_EVALUATION_DELAY_SECONDS * 1000;
+    const maxExpected = after + INITIAL_AI_EVALUATION_DELAY_SECONDS * 1000;
+    expect(next.getTime()).toBeGreaterThanOrEqual(minExpected - 500);
+    expect(next.getTime()).toBeLessThanOrEqual(maxExpected + 500);
+  });
+});

--- a/backend/src/messages/dto/find-history-query.dto.spec.ts
+++ b/backend/src/messages/dto/find-history-query.dto.spec.ts
@@ -1,0 +1,26 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { FindHistoryQueryDto } from './find-history-query.dto';
+
+describe('FindHistoryQueryDto', () => {
+  async function validatePlain(input: Record<string, unknown>) {
+    const dto = plainToInstance(FindHistoryQueryDto, input);
+    return validate(dto);
+  }
+
+  it('accepts valid limit and offset', async () => {
+    const errors = await validatePlain({ limit: 50, offset: 0 });
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects limit above 100', async () => {
+    const errors = await validatePlain({ limit: 101 });
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects negative offset', async () => {
+    const errors = await validatePlain({ offset: -1 });
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});

--- a/backend/src/messages/message-history.service.spec.ts
+++ b/backend/src/messages/message-history.service.spec.ts
@@ -1,0 +1,50 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MessageHistoryService } from './message-history.service';
+import { MessagesRepository } from './messages.repository';
+import type { Message } from '@prisma/client';
+
+describe('MessageHistoryService', () => {
+  let service: MessageHistoryService;
+  const mockRepo = { findHistory: jest.fn() };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MessageHistoryService,
+        { provide: MessagesRepository, useValue: mockRepo },
+      ],
+    }).compile();
+
+    service = module.get<MessageHistoryService>(MessageHistoryService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('reverses prisma order and serializes ids as strings', async () => {
+    const rows: Message[] = [
+      {
+        id: 2n,
+        chatroomId: 1n,
+        sender: 'user',
+        content: 'second',
+        createdAt: new Date('2020-01-02'),
+      } as Message,
+      {
+        id: 1n,
+        chatroomId: 1n,
+        sender: 'user',
+        content: 'first',
+        createdAt: new Date('2020-01-01'),
+      } as Message,
+    ];
+    mockRepo.findHistory.mockResolvedValue(rows);
+
+    const result = await service.findHistory(1, 10, 0);
+
+    expect(mockRepo.findHistory).toHaveBeenCalledWith(1n, 10, 0);
+    expect(result.map((m) => m.id)).toEqual(['1', '2']);
+    expect(result.map((m) => m.content)).toEqual(['first', 'second']);
+  });
+});

--- a/backend/src/messages/message-send.service.spec.ts
+++ b/backend/src/messages/message-send.service.spec.ts
@@ -1,0 +1,43 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MessageSendService } from './message-send.service';
+import { MessagesRepository } from './messages.repository';
+
+describe('MessageSendService', () => {
+  let service: MessageSendService;
+  const mockMessagesRepository = {
+    createMessage: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MessageSendService,
+        { provide: MessagesRepository, useValue: mockMessagesRepository },
+      ],
+    }).compile();
+
+    service = module.get<MessageSendService>(MessageSendService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('stores user message without AI metadata payload', async () => {
+    mockMessagesRepository.createMessage.mockResolvedValue({
+      id: 10n,
+      chatroomId: 1n,
+      sender: 'user',
+      content: 'hello',
+      createdAt: new Date('2026-04-24T00:00:00.000Z'),
+    });
+
+    await service.saveUserMessage(1, { content: 'hello' });
+
+    expect(mockMessagesRepository.createMessage).toHaveBeenCalledWith(
+      1n,
+      'user',
+      'hello',
+    );
+  });
+});

--- a/backend/src/messages/message-stream.service.spec.ts
+++ b/backend/src/messages/message-stream.service.spec.ts
@@ -1,0 +1,42 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MessageStreamService } from './message-stream.service';
+import { MessagesGateway } from './messages.gateway';
+
+describe('MessageStreamService', () => {
+  let service: MessageStreamService;
+  const mockGateway = {
+    emitTypingState: jest.fn(),
+    streamChunkToRoom: jest.fn(),
+    streamEndToRoom: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MessageStreamService,
+        { provide: MessagesGateway, useValue: mockGateway },
+      ],
+    }).compile();
+
+    service = module.get<MessageStreamService>(MessageStreamService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('setTyping forwards to gateway', () => {
+    service.setTyping(3, true);
+    expect(mockGateway.emitTypingState).toHaveBeenCalledWith(3, true);
+  });
+
+  it('streamChunk forwards to gateway', () => {
+    service.streamChunk(1, 'abc');
+    expect(mockGateway.streamChunkToRoom).toHaveBeenCalledWith(1, 'abc');
+  });
+
+  it('streamComplete converts messageId to number for gateway', () => {
+    service.streamComplete(2, 'full', '99');
+    expect(mockGateway.streamEndToRoom).toHaveBeenCalledWith(2, 'full', 99);
+  });
+});

--- a/backend/src/messages/messages.gateway.spec.ts
+++ b/backend/src/messages/messages.gateway.spec.ts
@@ -1,0 +1,63 @@
+import { Server, Socket } from 'socket.io';
+import { MessagesGateway } from './messages.gateway';
+
+describe('MessagesGateway', () => {
+  let gateway: MessagesGateway;
+  let emit: jest.Mock;
+  let to: jest.Mock;
+
+  beforeEach(() => {
+    gateway = new MessagesGateway();
+    emit = jest.fn();
+    to = jest.fn().mockReturnValue({ emit });
+    gateway.server = { to } as unknown as Server;
+  });
+
+  it('handleJoinRoom joins socket and returns joined payload', async () => {
+    const join = jest.fn().mockResolvedValue(undefined);
+    const client = { id: 'c1', join } as unknown as Socket;
+
+    const result = await gateway.handleJoinRoom({ chatroomId: 5 }, client);
+
+    expect(join).toHaveBeenCalledWith('chatroom_5');
+    expect(result).toEqual({ event: 'joined', data: { room: 5 } });
+  });
+
+  it('handleLeaveRoom leaves socket and returns left payload', async () => {
+    const leave = jest.fn().mockResolvedValue(undefined);
+    const client = { id: 'c2', leave } as unknown as Socket;
+
+    const result = await gateway.handleLeaveRoom({ chatroomId: 3 }, client);
+
+    expect(leave).toHaveBeenCalledWith('chatroom_3');
+    expect(result).toEqual({ event: 'left', data: { room: 3 } });
+  });
+
+  it('streamChunkToRoom emits ai_message_chunk', () => {
+    gateway.streamChunkToRoom(1, 'chunk');
+    expect(to).toHaveBeenCalledWith('chatroom_1');
+    expect(emit).toHaveBeenCalledWith('ai_message_chunk', {
+      chatroomId: 1,
+      chunk: 'chunk',
+    });
+  });
+
+  it('streamEndToRoom emits ai_message_complete', () => {
+    gateway.streamEndToRoom(2, 'full', 99);
+    expect(to).toHaveBeenCalledWith('chatroom_2');
+    expect(emit).toHaveBeenCalledWith('ai_message_complete', {
+      chatroomId: 2,
+      content: 'full',
+      messageId: 99,
+    });
+  });
+
+  it('emitTypingState emits ai_typing_state', () => {
+    gateway.emitTypingState(4, true);
+    expect(to).toHaveBeenCalledWith('chatroom_4');
+    expect(emit).toHaveBeenCalledWith('ai_typing_state', {
+      chatroomId: 4,
+      isTyping: true,
+    });
+  });
+});

--- a/backend/src/messages/messages.repository.spec.ts
+++ b/backend/src/messages/messages.repository.spec.ts
@@ -1,0 +1,114 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MessagesRepository } from './messages.repository';
+import { PrismaService } from '../prisma/prisma.service';
+
+describe('MessagesRepository', () => {
+  let repository: MessagesRepository;
+  const mockPrisma = {
+    message: {
+      findMany: jest.fn(),
+      create: jest.fn(),
+    },
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MessagesRepository,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+
+    repository = module.get<MessagesRepository>(MessagesRepository);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(repository).toBeDefined();
+  });
+
+  it('findHistory delegates to prisma with ordering and pagination', async () => {
+    mockPrisma.message.findMany.mockResolvedValue([]);
+    await repository.findHistory(9n, 20, 5);
+    expect(mockPrisma.message.findMany).toHaveBeenCalledWith({
+      where: { chatroomId: 9n },
+      orderBy: { createdAt: 'desc' },
+      take: 20,
+      skip: 5,
+    });
+  });
+
+  it('findRecent delegates to prisma', async () => {
+    mockPrisma.message.findMany.mockResolvedValue([]);
+    await repository.findRecent(1n, 10);
+    expect(mockPrisma.message.findMany).toHaveBeenCalledWith({
+      where: { chatroomId: 1n },
+      orderBy: { createdAt: 'desc' },
+      take: 10,
+    });
+  });
+
+  it('createMessage for user omits aiMessageMetadata', async () => {
+    mockPrisma.message.create.mockResolvedValue({ id: 1n });
+    await repository.createMessage(2n, 'user', 'hello');
+    expect(mockPrisma.message.create).toHaveBeenCalledWith({
+      data: {
+        chatroom: { connect: { id: 2n } },
+        sender: 'user',
+        content: 'hello',
+        aiMessageMetadata: undefined,
+      },
+    });
+  });
+
+  it('createMessage for ai includes metadata and triggerContext when set', async () => {
+    mockPrisma.message.create.mockResolvedValue({ id: 2n });
+    await repository.createMessage(2n, 'ai', 'reply', {
+      deliveryMode: 'reply',
+      triggerReason: 'user_message',
+      triggerContext: { key: 'v' },
+      readAt: null,
+    });
+    expect(mockPrisma.message.create).toHaveBeenCalledWith({
+      data: {
+        chatroom: { connect: { id: 2n } },
+        sender: 'ai',
+        content: 'reply',
+        aiMessageMetadata: {
+          create: {
+            readAt: null,
+            deliveryMode: 'reply',
+            triggerReason: 'user_message',
+            triggerContext: { key: 'v' },
+          },
+        },
+      },
+    });
+  });
+
+  it('createMessage for ai omits triggerContext key when null', async () => {
+    mockPrisma.message.create.mockResolvedValue({ id: 3n });
+    await repository.createMessage(2n, 'ai', 'hi', {
+      deliveryMode: 'reply',
+      triggerReason: 'scheduled',
+      triggerContext: null,
+    });
+    const createCalls = mockPrisma.message.create.mock
+      .calls as unknown as Array<
+      [
+        {
+          data: {
+            aiMessageMetadata: { create: Record<string, unknown> };
+          };
+        },
+      ]
+    >;
+    const createArg = createCalls[0][0];
+    expect(createArg.data.aiMessageMetadata.create).not.toHaveProperty(
+      'triggerContext',
+    );
+  });
+});

--- a/backend/src/messages/messages.repository.ts
+++ b/backend/src/messages/messages.repository.ts
@@ -1,6 +1,13 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
-import { Sender } from '@prisma/client';
+import { Prisma, Sender, type AiMessageDeliveryMode } from '@prisma/client';
+
+type CreateAiMessageMetadataInput = {
+  readAt?: Date | null;
+  deliveryMode: AiMessageDeliveryMode;
+  triggerReason: string;
+  triggerContext?: Prisma.InputJsonValue | null;
+};
 
 @Injectable()
 export class MessagesRepository {
@@ -23,12 +30,30 @@ export class MessagesRepository {
     });
   }
 
-  createMessage(chatroomId: bigint, sender: Sender, content: string) {
+  createMessage(
+    chatroomId: bigint,
+    sender: Sender,
+    content: string,
+    aiMetadata?: CreateAiMessageMetadataInput,
+  ) {
     return this.prisma.message.create({
       data: {
-        chatroomId,
+        chatroom: { connect: { id: chatroomId } },
         sender,
         content,
+        aiMessageMetadata:
+          sender === 'ai' && aiMetadata
+            ? {
+                create: {
+                  readAt: aiMetadata.readAt ?? null,
+                  deliveryMode: aiMetadata.deliveryMode,
+                  triggerReason: aiMetadata.triggerReason,
+                  ...(aiMetadata.triggerContext != null
+                    ? { triggerContext: aiMetadata.triggerContext }
+                    : {}),
+                },
+              }
+            : undefined,
       },
     });
   }

--- a/backend/src/messages/messages.service.spec.ts
+++ b/backend/src/messages/messages.service.spec.ts
@@ -1,3 +1,4 @@
+import { ForbiddenException, Logger } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { MessagesService } from './messages.service';
 import { MessageHistoryService } from './message-history.service';
@@ -59,6 +60,7 @@ describe('MessagesService', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+    mockFcmPushService.notifyVoluntaryAiMessage.mockResolvedValue(undefined);
   });
 
   it('should be defined', () => {
@@ -77,6 +79,15 @@ describe('MessagesService', () => {
       10,
       0,
     );
+  });
+
+  it('should reject findHistory when user does not own chatroom', async () => {
+    mockChatroomStateRepository.findByIdAndUser.mockResolvedValue(null);
+
+    await expect(service.findHistory('1', 1)).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+    expect(mockMessageHistoryService.findHistory).not.toHaveBeenCalled();
   });
 
   it('should send a message to AI and process background stream', async () => {
@@ -108,6 +119,90 @@ describe('MessagesService', () => {
     processMock.mockRestore();
   });
 
+  it('should log when background processing rejects after sendToAI', async () => {
+    const errSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
+    mockChatroomStateRepository.findByIdAndUser.mockResolvedValue({ id: 1n });
+    mockMessageSendService.saveUserMessage.mockResolvedValue({ id: 1n });
+    mockChatroomStateRepository.clearNextEvaluationTime.mockResolvedValue(
+      undefined,
+    );
+    jest
+      .spyOn(service, 'processBackgroundMessage')
+      .mockRejectedValue(new Error('bg fail'));
+
+    await service.sendToAI('1', 1, { content: 'x' });
+    await new Promise((r) => setImmediate(r));
+
+    expect(errSpy).toHaveBeenCalledWith(
+      'Background processing failed',
+      expect.any(Error),
+    );
+    errSpy.mockRestore();
+  });
+
+  it('should no-op processBackgroundMessage when chatroom is missing', async () => {
+    mockChatroomStateRepository.findById.mockResolvedValue(null);
+
+    await service.processBackgroundMessage(99, false);
+
+    expect(mockAiResponseService.generate).not.toHaveBeenCalled();
+  });
+
+  it('should warn when voluntary FCM notify fails', async () => {
+    const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+    mockChatroomStateRepository.findById.mockResolvedValue({
+      id: 1n,
+      userId: 2n,
+      name: 'Room',
+      basePrompt: '',
+    });
+    mockMessagesRepository.findRecent.mockResolvedValue([
+      {
+        id: 1n,
+        chatroomId: 1n,
+        sender: 'user',
+        content: 'hi',
+        createdAt: new Date(),
+      },
+    ]);
+    mockAiResponseService.generate.mockResolvedValue('done');
+    mockMessagesRepository.createMessage.mockResolvedValue({ id: 1n });
+    mockChatroomStateRepository.resetDelay.mockResolvedValue(undefined);
+    mockFcmPushService.notifyVoluntaryAiMessage.mockRejectedValue(
+      new Error('fcm down'),
+    );
+
+    await service.processBackgroundMessage(1, true);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      'FCM voluntary message notify failed',
+      expect.any(Error),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('should stop typing and reset delay when AI generation throws', async () => {
+    const errSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
+    mockChatroomStateRepository.findById.mockResolvedValue({
+      id: 1n,
+      userId: 2n,
+      name: 'Room',
+      basePrompt: '',
+    });
+    mockMessagesRepository.findRecent.mockResolvedValue([]);
+    mockAiResponseService.generate.mockRejectedValue(new Error('ollama'));
+
+    await service.processBackgroundMessage(3, false);
+
+    expect(mockMessageStreamService.setTyping).toHaveBeenCalledWith(3, false);
+    expect(mockChatroomStateRepository.resetDelay).toHaveBeenCalledWith(3n);
+    expect(errSpy).toHaveBeenCalledWith(
+      'Error processing AI message for room 3',
+      expect.any(Error),
+    );
+    errSpy.mockRestore();
+  });
+
   it('should notify FCM after a voluntary background message completes', async () => {
     mockChatroomStateRepository.findById.mockResolvedValue({
       id: 1n,
@@ -131,6 +226,15 @@ describe('MessagesService', () => {
     await service.processBackgroundMessage(1, true);
 
     expect(mockAiResponseService.generate).toHaveBeenCalled();
+    expect(mockMessagesRepository.createMessage).toHaveBeenCalledWith(
+      1n,
+      'ai',
+      'AI reply text',
+      expect.objectContaining({
+        deliveryMode: 'proactive',
+        triggerReason: 'scheduler_evaluation_yes',
+      }),
+    );
     const genArgs = mockAiResponseService.generate.mock.calls[0] as [
       { role: string; content: string }[],
       string,
@@ -175,6 +279,15 @@ describe('MessagesService', () => {
 
     await service.processBackgroundMessage(1, false);
 
+    expect(mockMessagesRepository.createMessage).toHaveBeenCalledWith(
+      1n,
+      'ai',
+      'reply',
+      expect.objectContaining({
+        deliveryMode: 'reply',
+        triggerReason: 'user_request',
+      }),
+    );
     expect(mockAiResponseService.generate).toHaveBeenCalledWith(
       [{ role: 'user', content: 'hello' }],
       `${NORMAL_CHAT_BASE_SYSTEM}\n\nYou are helpful.`,

--- a/backend/src/messages/messages.service.ts
+++ b/backend/src/messages/messages.service.ts
@@ -104,6 +104,13 @@ export class MessagesService {
         chatRoomIdBigInt,
         'ai',
         fullContent,
+        {
+          deliveryMode: voluntary ? 'proactive' : 'reply',
+          triggerReason: voluntary
+            ? 'scheduler_evaluation_yes'
+            : 'user_request',
+          triggerContext: voluntary ? { source: 'scheduler' } : null,
+        },
       );
       await this.chatroomStateRepository.resetDelay(chatRoomIdBigInt);
       this.messageStreamService.streamComplete(

--- a/backend/src/notifications/notifications.repository.spec.ts
+++ b/backend/src/notifications/notifications.repository.spec.ts
@@ -1,0 +1,91 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotificationsRepository } from './notifications.repository';
+import { PrismaService } from '../prisma/prisma.service';
+
+describe('NotificationsRepository', () => {
+  let repository: NotificationsRepository;
+  const mockPrisma = {
+    userDevice: {
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      findMany: jest.fn(),
+      deleteMany: jest.fn(),
+    },
+    chatroom: {
+      findUnique: jest.fn(),
+    },
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NotificationsRepository,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+
+    repository = module.get<NotificationsRepository>(NotificationsRepository);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('findDeviceByToken queries userDevice', async () => {
+    await repository.findDeviceByToken('tok');
+    expect(mockPrisma.userDevice.findUnique).toHaveBeenCalledWith({
+      where: { deviceToken: 'tok' },
+    });
+  });
+
+  it('findChatroomOwnerInfoById selects owner fields', async () => {
+    await repository.findChatroomOwnerInfoById(5n);
+    expect(mockPrisma.chatroom.findUnique).toHaveBeenCalledWith({
+      where: { id: 5n },
+      select: {
+        id: true,
+        name: true,
+        user: { select: { id: true, username: true } },
+      },
+    });
+  });
+
+  it('createDevice creates row', async () => {
+    await repository.createDevice(1n, 'd1');
+    expect(mockPrisma.userDevice.create).toHaveBeenCalledWith({
+      data: { userId: 1n, deviceToken: 'd1' },
+    });
+  });
+
+  it('updateDeviceOwner updates by token', async () => {
+    await repository.updateDeviceOwner('t', 9n);
+    expect(mockPrisma.userDevice.update).toHaveBeenCalledWith({
+      where: { deviceToken: 't' },
+      data: { userId: 9n },
+    });
+  });
+
+  it('findDeviceTokensByUserId returns tokens', async () => {
+    await repository.findDeviceTokensByUserId(3n);
+    expect(mockPrisma.userDevice.findMany).toHaveBeenCalledWith({
+      where: { userId: 3n },
+      select: { deviceToken: true },
+    });
+  });
+
+  it('deleteByDeviceTokens resolves count zero when empty', async () => {
+    const result = await repository.deleteByDeviceTokens([]);
+    expect(result).toEqual({ count: 0 });
+    expect(mockPrisma.userDevice.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it('deleteByDeviceTokens calls deleteMany when non-empty', async () => {
+    mockPrisma.userDevice.deleteMany.mockResolvedValue({ count: 2 });
+    const result = await repository.deleteByDeviceTokens(['a', 'b']);
+    expect(mockPrisma.userDevice.deleteMany).toHaveBeenCalledWith({
+      where: { deviceToken: { in: ['a', 'b'] } },
+    });
+    expect(result).toEqual({ count: 2 });
+  });
+});

--- a/backend/src/prisma/prisma.service.spec.ts
+++ b/backend/src/prisma/prisma.service.spec.ts
@@ -3,21 +3,39 @@ import { PrismaService } from './prisma.service';
 
 describe('PrismaService', () => {
   let service: PrismaService;
+  let $connectSpy: jest.SpiedFunction<PrismaService['$connect']>;
+  let $disconnectSpy: jest.SpiedFunction<PrismaService['$disconnect']>;
 
   beforeEach(async () => {
+    $connectSpy = jest
+      .spyOn(PrismaService.prototype, '$connect')
+      .mockResolvedValue(undefined);
+    $disconnectSpy = jest
+      .spyOn(PrismaService.prototype, '$disconnect')
+      .mockResolvedValue(undefined);
+
     const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        {
-          provide: PrismaService,
-          useValue: { $connect: jest.fn() },
-        },
-      ],
+      providers: [PrismaService],
     }).compile();
 
     service = module.get<PrismaService>(PrismaService);
   });
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('onModuleInit connects to the database', async () => {
+    await service.onModuleInit();
+    expect($connectSpy).toHaveBeenCalled();
+  });
+
+  it('onModuleDestroy disconnects from the database', async () => {
+    await service.onModuleDestroy();
+    expect($disconnectSpy).toHaveBeenCalled();
   });
 });

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -97,4 +97,3 @@ npm run test:coverage
 - API contract tests: `src/api/*.contract.test.ts`.
 - Integration flow tests: `tests/integration/*.integration.test.tsx`.
 - Shared test utilities and fixtures: `src/test/`.
-- Detailed conventions and checklist: `../contexts/FRONTEND_TESTING.md`.


### PR DESCRIPTION
## Summary
- Add Prisma `ai_message_metadata` model, migration, and message persistence wiring.
- Add backend Jest unit specs across modules and tune ESLint for coverage output.

## Why
- Ship structured metadata for AI-authored messages and proactive/reply delivery diagnostics.
- Improve regression safety with focused unit tests.

## Test plan
- [ ] backend: `npm run lint`
- [ ] backend: `npm run test`
- [ ] frontend: `npm run lint` (unchanged by this PR)
- [ ] frontend: `npm run typecheck` (unchanged)
- [ ] frontend: `npm run test` (unchanged)

## Rollback notes
- Revert merge commit; run down migration or restore DB from backup if migration was applied in an environment.

Made with [Cursor](https://cursor.com)