### PR TITLE
fix(chatrooms): keep required labels queryable and remove home github link

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,11 @@ Chatty is an AI chat application with real-time streamed replies and scheduled, 
 
 Best when you work on frontend or backend alone and want hot reload.
 
-1. **MySQL** (example using Compose for DB only):
+1. **MySQL**:
 
+   If you run the backend directly on your host machine, use a local MySQL instance that listens on `localhost:3306`.
+   The `mysql` service in `docker-compose.dev.yml` is intended for the full Docker stack and, as configured there, is not published to the host by default.
+   If you want to use Compose for MySQL while running the backend on the host, you must publish port `3306` to the host first; otherwise use the full-stack Docker setup below so the backend and DB run on the same Compose network.
    ```bash
    docker compose -f docker-compose.dev.yml up -d mysql
    ```

--- a/README.md
+++ b/README.md
@@ -1,79 +1,114 @@
 # Chatty
 
-Chatty is an AI-based chat application with real-time streamed responses and scheduled, voluntary AI messages. The project is organized as a local-first monorepo with a React frontend, NestJS backend, MySQL, and Ollama.
+Chatty is an AI chat application with real-time streamed replies and scheduled, voluntary AI messages. The repo is a monorepo: React frontend, NestJS backend, MySQL (Prisma), and Ollama for local LLM calls.
 
-## Core Capabilities
+## Core capabilities
 
-- Real-time AI response streaming over Socket.IO.
-- Slow-start voluntary AI trigger flow based on scheduled evaluations.
-- Multi-chatroom support with per-room prompt and profile image customization.
-- Clone and branch chatrooms for reusable conversation setups.
-- Optional Firebase Cloud Messaging (FCM) support for push notifications.
+- Real-time AI streaming over Socket.IO.
+- Voluntary AI messages driven by scheduled evaluations (slow-start style).
+- Multiple chatrooms with per-room base prompt and profile image.
+- Clone (copy settings) and branch (copy history + settings) chatrooms.
+- Optional Firebase Cloud Messaging (FCM) for push notifications.
 
-## Architecture Snapshot
+## Architecture
 
-- Frontend: React + TypeScript + Tailwind + TanStack Query
-- Backend: NestJS + TypeScript + Prisma
-- Database: MySQL
-- LLM runtime: Ollama (local)
-- Realtime: Socket.IO WebSocket events
-- Optional notifications: Firebase Admin / FCM
+| Layer | Technology |
+| --- | --- |
+| Frontend | React 19, TypeScript, Vite, Tailwind CSS 4, TanStack Query, Socket.IO client |
+| Backend | NestJS 11, TypeScript, Prisma |
+| Database | MySQL 8 |
+| LLM | Ollama (HTTP API) |
+| Realtime | Socket.IO |
+| Push (optional) | Firebase Admin (backend), Firebase Web + VAPID (frontend) |
 
-## Monorepo Layout
+## Repository layout
 
-- `frontend/`: React web app.
-- `backend/`: NestJS API + WebSocket gateway + scheduler logic.
-- `deploy/`: Docker/nginx deployment assets and deployment guide.
-- `.cursor/skills/`: reusable agent skills and reference documents.
-- `.cursor/rules/`: lightweight always-on or file-scoped agent rules.
+- `frontend/` — Vite SPA.
+- `backend/` — REST API, WebSocket gateway, cron-style scheduling, file uploads.
+- `deploy/` — nginx image, production Compose, deploy scripts, deployment notes.
+- `docker-compose.dev.yml` — local full stack: MySQL, backend, nginx (built frontend).
+- `.cursor/skills/` — agent skills and API reference material.
+- `.cursor/rules/` — editor/agent rules for this codebase.
 
-## Quick Start (Local Development)
+## Quick start (split local dev)
 
-Use this path when developing frontend/backend directly without Dockerized nginx.
+Best when you work on frontend or backend alone and want hot reload.
 
-1. Backend setup:
-   - Go to `backend/`.
-   - Install dependencies: `npm install`
-   - Configure `.env` (database/JWT/Ollama values)
-   - Run migrations: `npm run prisma:migrate:dev`
-   - Start dev server: `npm run dev`
-2. Frontend setup:
-   - Go to `frontend/`.
-   - Install dependencies: `npm install`
-   - Start dev server: `npm run dev`
+1. **MySQL** (example using Compose for DB only):
 
-For backend-specific commands and details, see `backend/README.md`.
-For frontend-specific commands and details, see `frontend/README.md`.
+   ```bash
+   docker compose -f docker-compose.dev.yml up -d mysql
+   ```
 
-## Quick Start (Docker Deployment)
+2. **Backend** (`backend/`):
 
-Use this path for a containerized stack (MySQL + backend + nginx-served frontend).
+   ```bash
+   npm install
+   ```
 
-1. Copy env template:
-   - `cp .env.docker.example .env`
-2. Build and run:
-   - `docker compose up -d --build`
-3. Open:
-   - `http://localhost:8080` (or your configured `PUBLIC_ORIGIN` / `HTTP_PORT`)
+   Create `backend/.env` (see `backend/README.md`). Then:
 
-Full deployment instructions and troubleshooting are documented in `deploy/README.md`.
+   ```bash
+   npm run prisma:migrate:dev
+   npm run dev
+   ```
 
-## API and WebSocket References
+   The API listens on **`http://localhost:8080`** unless you set `PORT`.
 
-REST and event contracts are documented in:
+3. **Frontend** (`frontend/`):
 
-- `.cursor/skills/api-development/references/API_DOCUMENTATION.md`
+   ```bash
+   npm install
+   cp .env.example .env
+   ```
 
-Important Socket.IO events include:
+   Set `VITE_API_URL` to your backend origin (no trailing slash), e.g. `http://localhost:8080`. Then:
 
-- Client -> Server: `joinRoom`, `leaveRoom`
-- Server -> Client: `ai_typing_state`, `ai_message_chunk`, `ai_message_complete`
+   ```bash
+   npm run dev
+   ```
 
-## Documentation Index
+   Vite serves the app (by default `http://localhost:5173`).
+
+Details: `backend/README.md`, `frontend/README.md`.
+
+## Quick start (Docker full stack)
+
+MySQL + backend + nginx serving the production build of the frontend.
+
+1. From the repo root:
+
+   ```bash
+   cp .env.docker.example .env
+   ```
+
+2. Adjust `.env` (JWT secret, origins, Ollama host/models, optional Firebase). If you change `PUBLIC_ORIGIN`, `CORS_ORIGIN`, or any `VITE_*` build args, rebuild images.
+
+3. Run:
+
+   ```bash
+   docker compose -f docker-compose.dev.yml up -d --build
+   ```
+
+4. Open **`http://localhost:8080`** (or the host/port matching `PUBLIC_ORIGIN` / `HTTP_PORT`).
+
+Full deployment and troubleshooting: `deploy/README.md`.
+
+## API and WebSocket reference
+
+- REST and Socket.IO contracts: `.cursor/skills/api-development/references/API_DOCUMENTATION.md`
+
+Common Socket.IO events:
+
+- Client → server: `joinRoom`, `leaveRoom`
+- Server → client: `ai_typing_state`, `ai_message_chunk`, `ai_message_complete`
+
+## Documentation index
 
 - Product proposal: `.cursor/references/PROJECT_PROPOSAL.md`
 - API contract: `.cursor/skills/api-development/references/API_DOCUMENTATION.md`
 - Data model: `.cursor/references/SCHEMA.md`
-- Backend guide: `backend/README.md`
-- Frontend guide: `frontend/README.md`
-- Deployment guide: `deploy/README.md`
+- Backend: `backend/README.md`
+- Frontend: `frontend/README.md`
+- Docker / deploy: `deploy/README.md`
+- CI/CD operations: `.github/ci-cd.md`

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,121 +1,121 @@
-# Chatty Backend
+# Chatty backend
 
-Chatty is a real-time, AI-based chat application backend built with **NestJS**, **TypeScript**, and **Prisma ORM**.
+NestJS API, Socket.IO streaming gateway, Prisma/MySQL persistence, Ollama integration, optional FCM, and scheduled voluntary-AI evaluation.
 
-## Tech Stack
-- **Framework**: [NestJS](https://nestjs.com/)
-- **Language**: [TypeScript](https://www.typescriptlang.org/)
-- **Database**: MySQL via [Prisma ORM](https://www.prisma.io/)
-- **Testing**: Jest & Supertest (Unit & E2E)
-- **Static Assets**: `@nestjs/serve-static` & `@nestjs/platform-express` (Multer) for image uploads
+## Tech stack
 
-## Git Workflow Convention
+- [NestJS](https://nestjs.com/) 11, TypeScript
+- [Prisma](https://www.prisma.io/) + MySQL 8
+- [Jest](https://jestjs.io/) + Supertest (unit + e2e)
+- Static uploads via `@nestjs/serve-static` and Multer (`@nestjs/platform-express`)
+- [Socket.IO](https://socket.io/) (`@nestjs/platform-socket.io`)
 
-Use the shared Git convention skill before creating branches, commits, and PRs:
+## Git workflow
+
+Shared branching, commits, and PR conventions:
 
 - `.cursor/skills/git/SKILL.md`
 
 ## Prerequisites
-- **Node.js** (v18+ recommended)
-- **MySQL** Server
 
-## Getting Started
+- Node.js 18+ (repo targets current LTS-style versions)
+- MySQL 8 (local install or Docker from root `docker-compose.dev.yml`)
 
-1. **Install Dependencies**
+## Getting started
+
+1. **Install dependencies** (Prisma Client is generated on `postinstall`):
+
    ```bash
    npm install
    ```
 
-2. **Environment Configuration**
-   Ensure you have a `.env` file at `backend/.env` containing your Database URL.
+2. **Environment** — create `backend/.env`:
+
    ```env
-   DATABASE_URL="mysql://<user>:<password>@localhost:3306/chatty"
+   DATABASE_URL="mysql://root:chatty_root@127.0.0.1:3306/chatty"
    JWT_SECRET="replace-with-a-strong-secret"
    JWT_EXPIRES_IN="7d"
    OLLAMA_HOST="http://127.0.0.1:11434"
-   OLLAMA_CHAT_MODEL="hf.co/soob3123/amoral-gemma3-12B-v2-qat-Q4_0-GGUF:Q4_0"
+   OLLAMA_CHAT_MODEL="qwen2.5:1.5b"
    OLLAMA_EVAL_MODEL="qwen2.5:1.5b"
    ```
 
-3. **Database Setup**
-   Run Prisma migrations and generate Prisma Client bindings:
+   Optional (push notifications; leave empty to disable FCM sends):
+
+   ```env
+   FIREBASE_SERVICE_ACCOUNT_JSON=
+   GOOGLE_APPLICATION_CREDENTIALS=
+   ```
+
+   **Port:** `PORT` defaults to **8080** in `main.ts` if unset.
+
+3. **Database**
+
    ```bash
    npm run prisma:migrate:dev
-   npx prisma generate
    ```
 
-4. **Running the Application**
+   `npx prisma generate` is not usually needed after `npm install`, but you can run it after schema changes if the client is stale.
+
+4. **Run**
+
    ```bash
-   # development
-   npm run start
-
-   # watch mode
-   npm run dev
-
-   # production mode
-   npm run start:prod
+   npm run dev          # watch mode (typical local dev)
+   npm run start        # single run
+   npm run start:prod   # production (compiled dist)
    ```
 
-## WebSocket Streaming
+## WebSocket streaming
 
-AI response streaming is delivered over Socket.IO via the backend gateway.
+Streaming lives on the **messages** gateway: `src/messages/messages.gateway.ts`.
 
-- Client events:
-  - `joinRoom` with `{ chatroomId: number }`
-  - `leaveRoom` with `{ chatroomId: number }`
-- Server events:
-  - `ai_typing_state` with `{ chatroomId: number, isTyping: boolean }`
-  - `ai_message_chunk` with `{ chatroomId: number, chunk: string }`
-  - `ai_message_complete` with `{ chatroomId: number, content: string, messageId: number }`
+- **Client → server**
+  - `joinRoom` — `{ chatroomId: number }`
+  - `leaveRoom` — `{ chatroomId: number }`
+- **Server → client**
+  - `ai_typing_state` — `{ chatroomId, isTyping }`
+  - `ai_message_chunk` — `{ chatroomId, chunk }`
+  - `ai_message_complete` — `{ chatroomId, content, messageId }`
 
-Note: current WebSocket room join/leave does not enforce JWT auth at gateway level.
+Join/leave handlers do not validate JWT at the gateway today; treat the socket surface accordingly for your threat model.
 
-## Features Implemented
-- **Chatrooms (CRUD)**: Create, View, Update, and Delete customized DB Chatrooms. Native file uploading handles saving profile images seamlessly locally into `src/assets` and hosts them via `.baseUrl`.
-- **Messages Management**: Send user messages to the AI and read chat histories attached securely to specific Chatroom constraints.
-- **Robust Testing**: Comprehensive Unit tests and End-to-End (E2E) Integration Tests spanning live Database evaluations (`/test/chatrooms.e2e-spec.ts` & `/test/messages.e2e-spec.ts`).
-- **JWT Authentication**: `POST /api/auth/login` issues bearer tokens used by protected API routes.
+## Features (high level)
 
-## Running Tests
+- **Auth** — `POST /api/auth/login` creates or loads a user and returns a JWT for Bearer-protected routes.
+- **Chatrooms** — CRUD, optional profile image upload, clone/branch flows.
+- **Messages** — history, user sends, streamed AI replies, background voluntary sends coordinated with tasks/cron.
+- **Notifications** — device registration and FCM when credentials are configured.
 
-```bash
-# Unit tests
-npm run test
-
-# End-to-End (E2E) integration tests
-npm run test:e2e
-
-# Test coverage
-npm run test:cov
-```
-
-## Linter & Formatter
+## Scripts
 
 ```bash
-# Run linting
-npm run lint
+npm run lint                 # ESLint
+npm run test                 # Unit tests (*.spec.ts under src/)
+npm run test:e2e             # E2E (test/*.e2e-spec.ts)
+npm run test:cov             # Coverage
+npm run prisma:migrate:dev   # Dev migrations
+npm run prisma:migrate:deploy # Deploy migrations (CI/prod)
 ```
 
-## Project Structure
-
-This section summarizes backend relationships, file layout, and the main request flow.
-
-### File Structure
+## Project structure
 
 ```text
 backend/
-├── prisma/              # Prisma schema, migrations, and DB setup
+├── prisma/                 # schema, migrations
 ├── src/
-│   ├── auth/            # Authentication (login, JWT handling)
-│   ├── chatrooms/       # Chatroom CRUD and configuration logic
-│   ├── messages/        # Message APIs and chat history operations
-│   ├── websocket/       # Socket.IO gateway and streaming events
-│   ├── assets/          # Uploaded/static files (e.g., profile images)
-│   └── ...              # Shared modules, bootstrap, and app wiring
-└── test/                # E2E and integration tests
+│   ├── auth/
+│   ├── chatrooms/
+│   ├── messages/           # REST + MessagesGateway (Socket.IO)
+│   ├── notifications/
+│   ├── tasks/              # scheduled evaluation / voluntary AI
+│   ├── ollama/
+│   ├── infrastructure/
+│   ├── common/
+│   └── ...
+└── test/                   # e2e specs (e.g. app, chatrooms, messages)
 ```
 
-### Entity Relations
+## Entity overview
 
 ```mermaid
 erDiagram
@@ -158,56 +158,47 @@ erDiagram
   }
 ```
 
-### Sequence Diagram
+## Request flow (simplified)
 
 ```mermaid
 sequenceDiagram
-  participant Client as FrontendClient
+  participant Client as Client
   participant Auth as AuthController
   participant Chatrooms as ChatroomsController
   participant Messages as MessagesController
-  participant Scheduler as CronTasksService
-  participant EvalAI as OllamaEvaluationModel
+  participant Tasks as TasksService
+  participant Eval as Ollama
   participant Push as FcmPushService
-  participant Gateway as ChatGateway
-  participant AI as AIService
-  participant DB as MySQLPrisma
+  participant Gateway as MessagesGateway
+  participant AI as AI streaming path
+  participant DB as Prisma
 
   Client->>Auth: POST /api/auth/login
-  Auth->>DB: validateOrCreateUser()
-  DB-->>Auth: user + tokenPayload
-  Auth-->>Client: JWT accessToken
+  Auth->>DB: user upsert / load
+  Auth-->>Client: JWT
 
-  Client->>Chatrooms: POST /api/chatrooms (Bearer JWT)
-  Chatrooms->>DB: create chatroom row
-  DB-->>Chatrooms: chatroom
-  Chatrooms-->>Client: created chatroom
+  Client->>Chatrooms: POST /api/chatrooms (Bearer)
+  Chatrooms->>DB: insert chatroom
+  Chatrooms-->>Client: chatroom
 
-  Client->>Messages: POST /api/messages (chatroomId, content)
-  Messages->>DB: store user message
-  Messages->>AI: request streamed response
-  AI-->>Gateway: chunks + completion events
+  Client->>Messages: POST /api/messages
+  Messages->>DB: user message
+  Messages->>AI: stream generation
+  AI-->>Gateway: chunks / complete
   Gateway-->>Client: ai_message_chunk / ai_message_complete
-  Messages->>DB: persist AI message
+  Messages->>DB: persist assistant message
 
-  opt Voluntary background evaluation flow
-    Scheduler->>DB: find rooms where nextEvaluationTime <= now
-    DB-->>Scheduler: eligible chatrooms
-    Scheduler->>DB: lock room (nextEvaluationTime = null)
-    Scheduler->>DB: load recent messages
-    Scheduler->>EvalAI: evaluateToAnswer(history, context)
-    EvalAI-->>Scheduler: shouldAnswer true/false
-
-    alt shouldAnswer is true
-      Scheduler->>Messages: processBackgroundMessage(chatroomId, voluntary=true)
-      Messages->>AI: generate voluntary response
-      AI-->>Gateway: ai_message_chunk / ai_message_complete
-      Gateway-->>Client: stream voluntary AI response
-      Messages->>DB: persist AI message and reset delay
-      Messages->>Push: notifyVoluntaryAiMessage()
-      Push-->>Client: push notification
-    else shouldAnswer is false
-      Scheduler->>DB: apply evaluation backoff and schedule nextEvaluationTime
+  opt Voluntary evaluation
+    Tasks->>DB: rooms due for evaluation
+    Tasks->>Eval: should answer?
+    Eval-->>Tasks: decision
+    alt send voluntary message
+      Tasks->>Messages: background send
+      Messages->>AI: stream
+      Gateway-->>Client: stream events
+      Messages->>Push: optional FCM
+    else defer
+      Tasks->>DB: backoff / nextEvaluationTime
     end
   end
 ```

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,94 +1,93 @@
-# Chatty Docker deployment (macOS-oriented)
+# Chatty Docker deployment (Compose)
 
-This guide runs Chatty with Docker Compose using:
+This guide runs the **development-oriented** full stack from the repository root using **`docker-compose.dev.yml`**:
 
-- `mysql`: MySQL 8
-- `backend`: NestJS API + WebSocket server
-- `nginx`: serves built frontend and proxies `/api`, `/socket.io`, and `/assets`
+- **mysql** — MySQL 8
+- **backend** — NestJS (API + Socket.IO) on port 8080 inside the network
+- **nginx** — serves the built SPA and proxies `/api`, `/socket.io`, and `/assets` to the backend
 
-## 1) Prerequisites
+Compose file path matters: there is no default `compose.yml` in the repo root, so always pass `-f docker-compose.dev.yml`.
 
-- Docker Desktop for Mac (or another compatible Docker engine).
-- Ollama running on the host machine so containers can reach `http://host.docker.internal:11434`.
-- Required Ollama models pulled locally (`OLLAMA_CHAT_MODEL`, `OLLAMA_EVAL_MODEL`).
+## Prerequisites
 
-## 2) Configure environment
+- Docker Engine with the Compose plugin (Docker Desktop, Colima, Linux engine, etc.).
+- **Ollama** reachable from the backend container:
+  - Default `OLLAMA_HOST` is `http://host.docker.internal:11434`.
+  - The Compose file sets `extra_hosts: host.docker.internal:host-gateway` so **Linux** hosts resolve `host.docker.internal` like Docker Desktop on macOS/Windows.
+- Models pulled on the machine that runs Ollama, matching `OLLAMA_CHAT_MODEL` and `OLLAMA_EVAL_MODEL` in `.env`.
 
-From the project root:
+## Configure environment
+
+From the **repository root**:
 
 ```bash
 cp .env.docker.example .env
 ```
 
-Update values in `.env` before first run:
+Review and adjust:
 
-- `JWT_SECRET` should be changed from the default placeholder.
-- `PUBLIC_ORIGIN` and `CORS_ORIGIN` should match the browser URL you will use.
-- `HTTP_PORT` controls host port mapping for nginx (default `8080`).
-- `OLLAMA_HOST` defaults to `http://host.docker.internal:11434` for local Ollama on macOS.
+- **`JWT_SECRET`** — replace the placeholder for anything beyond local play.
+- **`PUBLIC_ORIGIN`** and **`CORS_ORIGIN`** — must match the URL you open in the browser (scheme + host + port).
+- **`HTTP_PORT`** — host port mapped to nginx (default **8080**).
+- **`OLLAMA_HOST`** — where the backend container reaches Ollama (host gateway vs. LAN IP vs. remote URL).
 
-Important behavior notes:
-
-- If you change `PUBLIC_*` or any `VITE_*` variable, rebuild with `docker compose up --build` because frontend values are compile-time.
-- If you expose a different host/port (example: `http://127.0.0.1:3000`), align `PUBLIC_ORIGIN`, `CORS_ORIGIN`, and `HTTP_PORT`.
-
-## 3) Build and run
-
-From the project root:
+**Rebuild when build-time inputs change:** `PUBLIC_ORIGIN`, `CORS_ORIGIN`, any `VITE_*` variable, or nginx/Dockerfile changes require a new image build, for example:
 
 ```bash
-docker compose up --build
+docker compose -f docker-compose.dev.yml up -d --build
 ```
 
-Then open `PUBLIC_ORIGIN` in your browser (default `http://localhost:8080`).
+## Build and run
 
-## 4) Smoke test checklist
+```bash
+docker compose -f docker-compose.dev.yml up -d --build
+```
 
-1. **SPA**: app loads and login UI renders (optional Firebase warnings are acceptable when Firebase vars are unset).
-2. **REST**: login and list/create chatrooms through UI; requests should target `/api/...` on the same host.
-3. **WebSocket**: send a message in a chatroom and confirm streaming via Socket.IO (`/socket.io/`).
-4. **Profile image URL**: create/update chatroom with image and verify returned `profileImageUrl` uses your public origin.
-5. **Ollama reachability from backend container**:
+Open **`PUBLIC_ORIGIN`** in the browser (default `http://localhost:8080`).
+
+## Smoke test checklist
+
+1. **SPA** — app loads; login works (Firebase-related console noise is OK if web push env is unset).
+2. **REST** — login and chatroom list/create via UI hit `/api/...` on the same origin as the page.
+3. **WebSocket** — send a message; confirm streaming over Socket.IO (`/socket.io/`).
+4. **Profile images** — upload or set image URL; `profileImageUrl` should use your public origin where applicable.
+5. **Ollama from backend container:**
 
    ```bash
-   docker compose exec backend node -e "const h=(process.env.OLLAMA_HOST||'http://127.0.0.1:11434').replace(/\/$/,'');fetch(h+'/api/tags').then(r=>r.text()).then(console.log).catch(e=>{console.error(e);process.exit(1);})"
+   docker compose -f docker-compose.dev.yml exec backend node -e "const h=(process.env.OLLAMA_HOST||'http://127.0.0.1:11434').replace(/\/$/,'');fetch(h+'/api/tags').then(r=>r.text()).then(console.log).catch(e=>{console.error(e);process.exit(1);})"
    ```
 
-## 5) Troubleshooting
+## Troubleshooting
 
-### Prisma `P3009` failed migration (example: `widen_user_device_token`)
+### Prisma failed migration (`P3009`)
 
-If MySQL contains a failed migration row from an earlier attempt and backend exits during `migrate deploy`:
+If MySQL records a failed migration and the backend exits on `migrate deploy`:
 
-Option A: reset database state (destructive; drops all DB data):
-
-```bash
-docker compose down -v
-docker compose up --build
-```
-
-Option B: mark migration as rolled back, then restart backend:
+**Option A — reset (destructive):**
 
 ```bash
-docker compose exec backend npx prisma migrate resolve --rolled-back 20260408120000_widen_user_device_token
-docker compose restart backend
+docker compose -f docker-compose.dev.yml down -v
+docker compose -f docker-compose.dev.yml up -d --build
 ```
 
-### Common origin/port mismatch symptoms
+**Option B — resolve a specific migration** (example name from this repo; adjust if your error names another migration):
 
-- Browser cannot call API or WebSocket correctly.
-- Profile image URLs point to an unexpected host.
+```bash
+docker compose -f docker-compose.dev.yml exec backend npx prisma migrate resolve --rolled-back 20260408120000_widen_user_device_token
+docker compose -f docker-compose.dev.yml restart backend
+```
 
-Verify these values are aligned: `PUBLIC_ORIGIN`, `CORS_ORIGIN`, `HTTP_PORT`, and browser URL.
+### Origin / port mismatches
 
-## 6) CI/CD deployment notes
+Symptoms: API or WebSocket failures, wrong host in image URLs. Align **`PUBLIC_ORIGIN`**, **`CORS_ORIGIN`**, **`HTTP_PORT`**, and the browser URL, then rebuild.
 
-- GitHub CD workflow uses `deploy/docker-compose.prod.yml` and `deploy/scripts/deploy-prod.sh` for server-side pull-and-restart.
-- Ensure server has a populated `.env` in the deploy directory before first CD run.
-- Images are expected from GHCR with commit-SHA tags.
+## CI/CD
 
-## 7) Operational notes
+- GitHub **CD** builds and pushes images (see `.github/workflows/cd.yml`); images use commit-SHA tags in GHCR.
+- Server deploy uses **`deploy/docker-compose.prod.yml`** and **`deploy/scripts/deploy-prod.sh`** (copied or referenced per your ops runbook).
+- Required secrets, host layout, and health checks are documented in **`.github/ci-cd.md`**.
 
-- Uploaded files persist in Docker volume `backend_assets` (`ASSETS_DIR=/app/assets`).
-- `extra_hosts: host.docker.internal:host-gateway` is mainly for Linux compatibility; harmless on Docker Desktop for Mac.
-- For custom domain or HTTPS, terminate TLS at nginx and set `PUBLIC_ORIGIN` / `CORS_ORIGIN` to the final HTTPS URL.
+## Operations
+
+- Uploaded files persist in the Docker volume **`backend_assets`** (`ASSETS_DIR=/app/assets` in the backend service).
+- For HTTPS or a custom domain, terminate TLS at the edge (e.g. nginx or a reverse proxy) and set **`PUBLIC_ORIGIN`** / **`CORS_ORIGIN`** to the public HTTPS URL.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,5 +1,5 @@
 # Backend API URL (no trailing slash)
-VITE_API_URL=http://localhost:3000
+VITE_API_URL=http://localhost:8080
 
 # Firebase Web app config (Firebase Console → Project settings → Your apps)
 VITE_FIREBASE_API_KEY=

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,99 +1,84 @@
-# Chatty - Frontend
+# Chatty frontend
+
+Vite + React 19 SPA for multi-room chat, Socket.IO streaming, optional web push (FCM), and chatroom management (create, edit, clone, branch).
 
 ## Purpose
 
-Chatty is an intelligent, web-based AI Chat application. Unlike traditional AI chatbots that only respond to user input, Chatty features a scheduling algorithm that allows the AI to _voluntarily_ initiate conversations and send messages to users without waiting for user requests.
+Chatty supports both user-initiated messages and **voluntary** AI messages: the backend runs evaluations on a schedule; the UI reflects streaming replies and can surface push notifications when Firebase is configured.
 
-It provides real-time streaming of messages using local LLMs (via Ollama) and acts as an "Evaluator" to decide if the AI should initiate a chat.
+## Tech stack
 
-## Frontend Specifications
-
-The frontend architecture prioritizes performance optimization, strict TypeScript implementation, and modular design.
-
-### Tech Stack
-
-- **Core Framework:** React (using Vite)
-- **Language:** Strict TypeScript
-- **Styling:** Tailwind CSS (with utility libraries like `clsx` and `tailwind-merge` for readability)
-- **Data Fetching & State Management:** TanStack Query (React Query)
-- **Real-Time Communication:** WebSockets (character-by-character text streaming)
-- **Push Notifications:** Firebase Cloud Messaging (Web Push / Service Worker API)
-
-### Key Features
-
-- **Real-time Streamed Responses:** Custom hooks (`useWebSocketStream`) handle incoming chunks of message data in real-time, computing deltas and smoothly updating the UI without entire app re-renders.
-- **Voluntary AI Chat & Notifications:** Integration with FCM to deliver push notifications indicating voluntary AI messages using a slow-start check scheduling algorithm.
-- **Advanced Chatroom Management:** Support for multiple chatrooms with separate contexts. Users can create, update, delete, clone (copy prompt/image config), and branch (copy history + config) chatrooms.
-- **AI Customization:** Users can independently tailor the underlying base prompt and AI profile image for each chatroom environment.
-
-### Architectural Priorities
-
-- **Clean Abstractions:** Complex business logic and API connections are decoupled into centralized, generic custom hooks (`useChatrooms`, `useMessages`, `useNotifications`, etc.).
-- **Strict Typing:** All REST endpoints and WebSocket channels are guarded by explicit TypeScript interfaces (`src/types/api.ts`).
+- **React 19**, **TypeScript**, **Vite 7**
+- **Tailwind CSS 4** (`@tailwindcss/vite`), `clsx`, `tailwind-merge`
+- **TanStack Query** for server state
+- **Socket.IO client** for realtime chunks and typing state
+- **React Router 7** for routing
+- **Firebase** (optional) for FCM / web push; **vite-plugin-pwa** for the service worker shell
+- **Vitest** + Testing Library for tests
 
 ## Prerequisites
 
-- **Node.js** (v18+ recommended)
-- Running backend API (default local backend URL: `http://localhost:3000`)
+- Node.js 18+
+- Running Chatty backend (default in this repo: **`http://localhost:8080`** — set `VITE_API_URL` to match)
 
-## Getting Started
-
-1. **Install Dependencies**
-   ```bash
-   npm install
-   ```
-2. **Environment Configuration**
-   Create `frontend/.env` (optional for local basic usage) and set values as needed:
-   ```env
-   VITE_API_URL=http://localhost:3000
-   VITE_FIREBASE_API_KEY=
-   VITE_FIREBASE_AUTH_DOMAIN=
-   VITE_FIREBASE_PROJECT_ID=
-   VITE_FIREBASE_MESSAGING_SENDER_ID=
-   VITE_FIREBASE_APP_ID=
-   VITE_FCM_VAPID_KEY=
-   ```
-3. **Run Development Server**
-   ```bash
-   npm run dev
-   ```
-4. **Build Production Bundle**
-   ```bash
-   npm run build
-   npm run preview
-   ```
-
-## Available Scripts
+## Getting started
 
 ```bash
-# Development server
-npm run dev
-
-# Type-check + production build
-npm run build
-
-# Lint source files
-npm run lint
-
-# TypeScript project checks
-npm run typecheck
-
-# Run unit/component tests
-npm run test
-
-# Run unit-only tests
-npm run test:unit
-
-# Run integration flow tests
-npm run test:integration
-
-# Run test suite with coverage report
-npm run test:coverage
+npm install
+cp .env.example .env
 ```
 
-## Testing
+Edit `.env`:
 
-- Unit/component/hook tests: colocated as `src/**/<name>.test.ts(x)`.
-- API contract tests: `src/api/*.contract.test.ts`.
-- Integration flow tests: `tests/integration/*.integration.test.tsx`.
-- Shared test utilities and fixtures: `src/test/`.
+- **`VITE_API_URL`** — backend origin, **no trailing slash** (e.g. `http://localhost:8080` for local Nest with default `PORT`).
+- **Firebase / `VITE_FCM_VAPID_KEY`** — optional; omit for local UI flows without push.
+
+```bash
+npm run dev
+```
+
+Production build and preview:
+
+```bash
+npm run build
+npm run preview
+```
+
+## Environment variables
+
+| Variable | Purpose |
+| --- | --- |
+| `VITE_API_URL` | REST + Socket.IO base (same host/path the browser uses to reach the API). |
+| `VITE_FIREBASE_*` | Firebase web app config for FCM. |
+| `VITE_FCM_VAPID_KEY` | Web Push VAPID key from Firebase Console. |
+| `VITE_RELEASE_SHA`, `VITE_RELEASE_BUILT_AT` | Optional build metadata (e.g. CI). |
+
+## Scripts
+
+```bash
+npm run dev                 # Vite dev server (--host)
+npm run build               # tsc -b && vite build
+npm run preview             # Preview production build
+npm run lint                # ESLint
+npm run typecheck           # TypeScript project references
+npm run test                # Vitest run (all configured tests)
+npm run test:unit           # Under src/
+npm run test:integration    # tests/integration/
+npm run test:ui             # Vitest UI
+npm run test:coverage       # Coverage report
+npm run test:coverage:enforce  # Coverage with enforcement flag
+```
+
+## Architecture notes
+
+- **Hooks** — data and side effects are grouped in hooks such as chatrooms, messages, notifications, and websocket streaming (deltas for partial AI text).
+- **Types** — REST shapes and enums are centralized (e.g. `src/types/api.ts`) to stay aligned with the backend contract.
+- **State** — TanStack Query for remote data; lightweight client state where appropriate (e.g. Zustand where used).
+
+## Testing layout
+
+- **Unit / component / hook tests** — colocated as `src/**/<name>.test.ts(x)`.
+- **API contract tests** — `src/api/*.contract.test.ts`.
+- **Integration flows** — `tests/integration/*.integration.test.tsx`.
+- **Shared helpers** — `src/test/` (fixtures, render helpers).
+- **Shared mocks** — `src/test/mocks/` (see `src/test/mocks/README.md`).

--- a/frontend/src/features/chatrooms/components/ChatroomConfiguration.test.tsx
+++ b/frontend/src/features/chatrooms/components/ChatroomConfiguration.test.tsx
@@ -52,9 +52,9 @@ describe('ChatroomConfiguration', () => {
 
   it('supports promptRequired true/false', () => {
     const { rerender } = render(<ChatroomConfiguration {...baseProps()} promptRequired />)
-    expect(screen.getByLabelText('Base Prompt')).toHaveProperty('required', true)
+    expect(screen.getByLabelText(/Base Prompt/i)).toHaveProperty('required', true)
 
     rerender(<ChatroomConfiguration {...baseProps()} promptRequired={false} />)
-    expect(screen.getByLabelText('Base Prompt')).toHaveProperty('required', false)
+    expect(screen.getByLabelText(/Base Prompt/i)).toHaveProperty('required', false)
   })
 })

--- a/frontend/src/features/chatrooms/components/ChatroomConfiguration.tsx
+++ b/frontend/src/features/chatrooms/components/ChatroomConfiguration.tsx
@@ -11,6 +11,7 @@ export interface ChatroomConfigurationProps {
   promptFieldId: string
   basePrompt: string
   onBasePromptChange: (e: ChangeEvent<HTMLTextAreaElement>) => void
+  nameRequired?: boolean
   promptRequired?: boolean
   imageFieldId: string
   previewUrl: string | null
@@ -27,6 +28,7 @@ export default function ChatroomConfiguration({
   promptFieldId,
   basePrompt,
   onBasePromptChange,
+  nameRequired = true,
   promptRequired = true,
   imageFieldId,
   previewUrl,
@@ -40,6 +42,12 @@ export default function ChatroomConfiguration({
       <div>
         <label htmlFor={nameFieldId} className="block text-sm font-medium text-gray-700 mb-1">
           Name
+          {nameRequired && (
+            <span className="ml-1 text-red-500" aria-hidden="true">
+              *
+            </span>
+          )}
+          {nameRequired && <span className="sr-only"> (required)</span>}
         </label>
         <Input
           id={nameFieldId}
@@ -47,6 +55,7 @@ export default function ChatroomConfiguration({
           placeholder="e.g., Frontend Team"
           value={name}
           onChange={onNameChange}
+          required={nameRequired}
         />
       </div>
 

--- a/frontend/src/features/chatrooms/components/ChatroomConfiguration.tsx
+++ b/frontend/src/features/chatrooms/components/ChatroomConfiguration.tsx
@@ -53,6 +53,12 @@ export default function ChatroomConfiguration({
       <div>
         <label htmlFor={promptFieldId} className="block text-sm font-medium text-gray-700 mb-1">
           Base Prompt
+          {promptRequired && (
+            <span className="ml-1 text-red-500" aria-hidden="true">
+              *
+            </span>
+          )}
+          {promptRequired && <span className="sr-only"> (required)</span>}
         </label>
         <textarea
           id={promptFieldId}

--- a/frontend/src/features/chatrooms/components/CreateChatroomModal.test.tsx
+++ b/frontend/src/features/chatrooms/components/CreateChatroomModal.test.tsx
@@ -68,7 +68,7 @@ describe('CreateChatroomModal', () => {
     render(<CreateChatroomModal isOpen onClose={onClose} onSubmit={vi.fn()} />)
 
     fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'To reset' } })
-    fireEvent.change(screen.getByLabelText(/Base Prompt/i), { target: { value: 'To reset' } })
+    fireEvent.change(screen.getByLabelText(/Base Prompt/i), { target: { value: 'Reset prompt' } })
 
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
 

--- a/frontend/src/features/chatrooms/components/CreateChatroomModal.test.tsx
+++ b/frontend/src/features/chatrooms/components/CreateChatroomModal.test.tsx
@@ -36,8 +36,8 @@ describe('CreateChatroomModal', () => {
     const onSubmit = vi.fn()
     render(<CreateChatroomModal isOpen onClose={vi.fn()} onSubmit={onSubmit} />)
 
-    fireEvent.change(screen.getByLabelText('Name'), { target: { value: '  Team Alpha  ' } })
-    fireEvent.change(screen.getByLabelText('Base Prompt'), { target: { value: '  Be concise  ' } })
+    fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: '  Team Alpha  ' } })
+    fireEvent.change(screen.getByLabelText(/Base Prompt/i), { target: { value: '  Be concise  ' } })
     fireEvent.click(screen.getByRole('button', { name: 'Create' }))
 
     expect(onSubmit).toHaveBeenCalledWith({
@@ -52,8 +52,8 @@ describe('CreateChatroomModal', () => {
 
     render(<CreateChatroomModal isOpen onClose={vi.fn()} onSubmit={onSubmit} />)
 
-    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Room' } })
-    fireEvent.change(screen.getByLabelText('Base Prompt'), { target: { value: 'Prompt' } })
+    fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'Room' } })
+    fireEvent.change(screen.getByLabelText(/Base Prompt/i), { target: { value: 'Prompt' } })
     fireEvent.click(screen.getByRole('button', { name: 'Create' }))
 
     expect(onSubmit).toHaveBeenCalledWith({
@@ -67,8 +67,8 @@ describe('CreateChatroomModal', () => {
     const onClose = vi.fn()
     render(<CreateChatroomModal isOpen onClose={onClose} onSubmit={vi.fn()} />)
 
-    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'To reset' } })
-    fireEvent.change(screen.getByLabelText('Base Prompt'), { target: { value: 'To reset prompt' } })
+    fireEvent.change(screen.getByLabelText(/Name/i), { target: { value: 'To reset' } })
+    fireEvent.change(screen.getByLabelText(/Base Prompt/i), { target: { value: 'To reset' } })
 
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
 

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,6 +1,5 @@
 import { Navigate, useLocation } from 'react-router'
 import Button from '../shared/ui/Button'
-import GithubLink from '../shared/ui/GithubLink'
 import CreateChatroomModal from '../features/chatrooms/components/CreateChatroomModal'
 import { useCreateChatroomFlow } from '../features/chatrooms/hooks/useCreateChatroomFlow'
 import { useChatrooms } from '../features/chatrooms/hooks/useChatrooms'
@@ -46,7 +45,6 @@ export default function HomePage() {
       <Button variant="primary" size="lg" className="shadow-sm" onClick={openCreateModal}>
         Create New Chatroom
       </Button>
-      <GithubLink size="medium" className="mt-4" />
 
       <CreateChatroomModal
         isOpen={isCreateModalOpen}

--- a/frontend/src/test/mocks/README.md
+++ b/frontend/src/test/mocks/README.md
@@ -1,1 +1,9 @@
-Test doubles shared across frontend suites live here.
+# Shared test mocks
+
+Place **Vitest mocks** here when multiple suites need the same module replacement (for example Firebase, `socket.io-client`, or browser APIs).
+
+- Prefer **colocated** `vi.mock(...)` next to a single test file when the double is not reused.
+- Use this folder for **`__mocks__` subdirectories** or small mock modules imported from `src/**/*.test.ts(x)` and `tests/integration/**`.
+- Keep mocks **minimal**: only implement the surface your tests exercise so failures stay easy to interpret.
+
+Related: shared render helpers and fixtures live under `src/test/` (parent of `mocks/`).


### PR DESCRIPTION
## Summary
- add `nameRequired` handling in `ChatroomConfiguration` so required-state UI stays explicit while preserving accessible label queries
- update chatroom modal/configuration tests to use regex label lookups that remain stable with required marker text
- remove the home page GitHub link CTA to simplify the primary creation flow

## Why
- required indicators changed label text and made strict string-based test selectors brittle
- the home hero now focuses on chatroom creation as the primary action

## Test plan
- [ ] frontend: `npm run lint`
- [ ] frontend: `npm run typecheck`
- [ ] frontend: `npm run test`

## Rollback notes
- revert commit `f05e3e7` to restore prior label behavior and home page link rendering

Made with [Cursor](https://cursor.com)