### PR TITLE
refactor(backend): modularize inference layer

### DIFF
--- a/backend/src/inference/tasks/chat-generation.service.ts
+++ b/backend/src/inference/tasks/chat-generation.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import {
   CHAT_COMPLETION_PORT,
-  ChatCompletionPort,
+  type ChatCompletionPort,
 } from '../ports/chat-completion.port';
 import { ChatMessage } from '../shared/chat-message';
 import {

--- a/backend/src/inference/tasks/voluntary-evaluator.service.ts
+++ b/backend/src/inference/tasks/voluntary-evaluator.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import {
   CLASSIFICATION_PORT,
-  ClassificationPort,
+  type ClassificationPort,
 } from '../ports/classification.port';
 import { buildVoluntaryEvaluationPrompt } from '../prompts/voluntary-evaluator.prompt';
 import { ChatMessage } from '../shared/chat-message';


### PR DESCRIPTION
## Summary
- Replace the old monolithic Ollama service/module with a new `inference` module using explicit chat-completion and classification ports.
- Move inference prompts/options/history utilities into dedicated inference folders and wire `messages`/`tasks` to consume `ChatGenerationService` and `VoluntaryEvaluatorService`.
- Add focused unit tests for the new inference adapters/services and update existing task/message tests to the new architecture.

## Why
- This separates provider-specific code from task/application logic, making inference behavior easier to maintain, test, and extend.

## Test plan
- [ ] backend: `npm run lint`
- [ ] backend: `npm run test`

## Rollback notes
- Revert this PR to restore the previous `ollama` module/service path and message/task integrations.

Made with [Cursor](https://cursor.com)