### PR TITLE
ci(ci): add build steps to backend and frontend checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,10 @@ jobs:
         if: needs.changes.outputs.backend == 'true'
         run: npm run test -- --runInBand
 
+      - name: Build
+        if: needs.changes.outputs.backend == 'true'
+        run: npm run build
+
       - name: Skip backend checks when unchanged
         if: needs.changes.outputs.backend != 'true'
         run: echo "No backend changes detected."
@@ -112,6 +116,10 @@ jobs:
       - name: Test
         if: needs.changes.outputs.frontend == 'true'
         run: npm run test
+
+      - name: Build
+        if: needs.changes.outputs.frontend == 'true'
+        run: npm run build
 
       - name: Skip frontend checks when unchanged
         if: needs.changes.outputs.frontend != 'true'


### PR DESCRIPTION
## Summary
- Add a backend build step to CI when backend paths change
- Add a frontend build step to CI when frontend paths change
- Keep skip behavior unchanged when no relevant paths are modified

## Why
- Catch build-time issues earlier in CI instead of discovering them after tests pass

## Test plan
- [x] Verify workflow YAML diff and conditions for backend/frontend jobs
- [ ] Run CI on this PR and confirm new build steps execute on changed paths

## Rollback notes
- Revert this PR to remove the added build steps and restore previous CI behavior

Made with [Cursor](https://cursor.com)