### PR TITLE
feat(messages): add qdrant-backed embedding memory retrieval

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -20,6 +20,15 @@ CORS_ORIGIN=http://localhost:8080
 OLLAMA_HOST=http://host.docker.internal:11434
 OLLAMA_CHAT_MODEL=qwen2.5:1.5b
 OLLAMA_EVAL_MODEL=qwen2.5:1.5b
+OLLAMA_EMBED_MODEL=all-minilm
+
+# Qdrant (vector storage for long-term memory retrieval)
+QDRANT_URL=http://qdrant:6333
+QDRANT_COLLECTION=chat_memory
+RAG_RECENT_WINDOW=8
+RAG_TOP_K=5
+RAG_MIN_SCORE=0.4
+RAG_SNIPPET_CHARS=200
 
 # FCM (optional). Either set JSON inline or mount a file and set GOOGLE_APPLICATION_CREDENTIALS inside the container.
 FIREBASE_SERVICE_ACCOUNT_JSON=

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Chatty
 
-Chatty is an AI chat application with real-time streamed replies and scheduled, proactive AI messages. The repo is a monorepo: React frontend, NestJS backend, MySQL (Prisma), and Ollama for local LLM calls.
+Chatty is an AI chat application with real-time streamed replies and scheduled, proactive AI messages. The repo is a monorepo: React frontend, NestJS backend, MySQL (Prisma), Ollama for local LLM calls/embeddings, and Qdrant for long-term memory retrieval.
 
 ## Core capabilities
 
@@ -18,6 +18,7 @@ Chatty is an AI chat application with real-time streamed replies and scheduled, 
 | Backend         | NestJS 11, TypeScript, Prisma                                                |
 | Database        | MySQL 8                                                                      |
 | LLM             | Ollama (HTTP API)                                                            |
+| Vector store    | Qdrant                                                                        |
 | Realtime        | Socket.IO                                                                    |
 | Push (optional) | Firebase Admin (backend), Firebase Web + VAPID (frontend)                    |
 
@@ -86,7 +87,13 @@ MySQL + backend + nginx serving the production build of the frontend.
    cp .env.docker.example .env
    ```
 
-2. Adjust `.env` (JWT secret, origins, Ollama host/models, optional Firebase). If you change `PUBLIC_ORIGIN`, `CORS_ORIGIN`, or any `VITE_*` build args, rebuild images.
+2. Adjust `.env` (JWT secret, origins, Ollama host/models, optional Firebase, Qdrant settings). If you change `PUBLIC_ORIGIN`, `CORS_ORIGIN`, or any `VITE_*` build args, rebuild images.
+
+   Pull the embedding model on your host before first run:
+
+   ```bash
+   ollama pull all-minilm
+   ```
 
 3. Run:
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,11 +1,12 @@
 # Chatty backend
 
-NestJS API, Socket.IO streaming gateway, Prisma/MySQL persistence, Ollama integration, optional FCM, and scheduled evaluation for proactive AI message.
+NestJS API, Socket.IO streaming gateway, Prisma/MySQL persistence, Ollama integration, Qdrant-backed long-term memory retrieval (RAG), optional FCM, and scheduled evaluation for proactive AI message.
 
 ## Tech stack
 
 - [NestJS](https://nestjs.com/) 11, TypeScript
 - [Prisma](https://www.prisma.io/) + MySQL 8
+- [Qdrant](https://qdrant.tech/) vector store for long-term memory search
 - [Jest](https://jestjs.io/) + Supertest (unit + e2e)
 - Static uploads via `@nestjs/serve-static` and Multer (`@nestjs/platform-express`)
 - [Socket.IO](https://socket.io/) (`@nestjs/platform-socket.io`)
@@ -38,6 +39,19 @@ Shared branching, commits, and PR conventions:
    OLLAMA_HOST="http://127.0.0.1:11434"
    OLLAMA_CHAT_MODEL="qwen2.5:1.5b"
    OLLAMA_EVAL_MODEL="qwen2.5:1.5b"
+   OLLAMA_EMBED_MODEL="all-minilm"
+   QDRANT_URL="http://127.0.0.1:6333"
+   QDRANT_COLLECTION="chat_memory"
+   RAG_RECENT_WINDOW="8"
+   RAG_TOP_K="5"
+   RAG_MIN_SCORE="0.4"
+   RAG_SNIPPET_CHARS="200"
+   ```
+
+   Pull the local embedding model once:
+
+   ```bash
+   ollama pull all-minilm
    ```
 
    Optional (push notifications; leave empty to disable FCM sends):

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "backend",
       "version": "0.0.1",
+      "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {
         "@nestjs/common": "^11.0.1",
@@ -21,6 +22,7 @@
         "@nestjs/serve-static": "^5.0.4",
         "@nestjs/websockets": "^11.1.18",
         "@prisma/client": "^6.4.1",
+        "@qdrant/js-client-rest": "^1.17.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.15.1",
         "dotenv": "^17.4.0",
@@ -3495,6 +3497,33 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause",
       "optional": true
+    },
+    "node_modules/@qdrant/js-client-rest": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@qdrant/js-client-rest/-/js-client-rest-1.17.0.tgz",
+      "integrity": "sha512-aZFQeirWVqWAa1a8vJ957LMzcXkFHGbsoRhzc8AkGfg6V0jtK8PlG8/eyyc2xhYsR961FDDx1Tx6nyE0K7lS+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@qdrant/openapi-typescript-fetch": "1.2.6",
+        "undici": "^6.23.0"
+      },
+      "engines": {
+        "node": ">=18.17.0",
+        "pnpm": ">=8"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.7"
+      }
+    },
+    "node_modules/@qdrant/openapi-typescript-fetch": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@qdrant/openapi-typescript-fetch/-/openapi-typescript-fetch-1.2.6.tgz",
+      "integrity": "sha512-oQG/FejNpItrxRHoyctYvT3rwGZOnK4jr3JdppO/c78ktDvkWiPXPHNsrDf33K9sZdRb6PR7gi4noIapu5q4HA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0",
+        "pnpm": ">=8"
+      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.49",
@@ -11900,7 +11929,6 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -11970,6 +11998,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -35,6 +35,7 @@
     "@nestjs/serve-static": "^5.0.4",
     "@nestjs/websockets": "^11.1.18",
     "@prisma/client": "^6.4.1",
+    "@qdrant/js-client-rest": "^1.17.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.15.1",
     "dotenv": "^17.4.0",

--- a/backend/src/inference/inference.module.ts
+++ b/backend/src/inference/inference.module.ts
@@ -6,6 +6,10 @@ import { ProactiveEvaluatorService } from './tasks/proactive-evaluator.service';
 @Module({
   imports: [OllamaProviderModule],
   providers: [ChatGenerationService, ProactiveEvaluatorService],
-  exports: [ChatGenerationService, ProactiveEvaluatorService],
+  exports: [
+    ChatGenerationService,
+    ProactiveEvaluatorService,
+    OllamaProviderModule,
+  ],
 })
 export class InferenceModule {}

--- a/backend/src/inference/ports/embedding.port.ts
+++ b/backend/src/inference/ports/embedding.port.ts
@@ -1,0 +1,6 @@
+export const EMBEDDING_PORT = Symbol('EmbeddingPort');
+
+export interface EmbeddingPort {
+  embed(text: string): Promise<number[]>;
+  embedBatch(texts: string[]): Promise<number[][]>;
+}

--- a/backend/src/inference/providers/ollama/ollama-embedding.adapter.spec.ts
+++ b/backend/src/inference/providers/ollama/ollama-embedding.adapter.spec.ts
@@ -1,0 +1,68 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { Ollama } from 'ollama';
+import { OllamaEmbeddingAdapter } from './ollama-embedding.adapter';
+import { OLLAMA_CLIENT } from './ollama-client.provider';
+
+describe('OllamaEmbeddingAdapter', () => {
+  let adapter: OllamaEmbeddingAdapter;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OllamaEmbeddingAdapter,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string, fallback: string) => fallback),
+          },
+        },
+        {
+          provide: OLLAMA_CLIENT,
+          useValue: {
+            embed: jest.fn(),
+          } as unknown as Ollama,
+        },
+      ],
+    }).compile();
+
+    adapter = module.get<OllamaEmbeddingAdapter>(OllamaEmbeddingAdapter);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('embeds a single text input', async () => {
+    const ollama = (adapter as any).ollama as { embed: jest.Mock };
+    ollama.embed.mockResolvedValue({
+      embeddings: [[0.1, 0.2, 0.3]],
+    });
+
+    const embedding = await adapter.embed('hello');
+
+    expect(embedding).toEqual([0.1, 0.2, 0.3]);
+    expect(ollama.embed).toHaveBeenCalledWith({
+      model: 'all-minilm',
+      input: 'hello',
+    });
+  });
+
+  it('embeds batch inputs', async () => {
+    const ollama = (adapter as any).ollama as { embed: jest.Mock };
+    ollama.embed.mockResolvedValue({
+      embeddings: [
+        [0.1, 0.2],
+        [0.4, 0.5],
+      ],
+    });
+
+    const embeddings = await adapter.embedBatch(['a', 'b']);
+
+    expect(embeddings).toEqual([
+      [0.1, 0.2],
+      [0.4, 0.5],
+    ]);
+  });
+});

--- a/backend/src/inference/providers/ollama/ollama-embedding.adapter.ts
+++ b/backend/src/inference/providers/ollama/ollama-embedding.adapter.ts
@@ -1,0 +1,41 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Ollama } from 'ollama';
+import { EmbeddingPort } from '../../ports/embedding.port';
+import { OLLAMA_CLIENT } from './ollama-client.provider';
+
+@Injectable()
+export class OllamaEmbeddingAdapter implements EmbeddingPort {
+  private readonly embedModel: string;
+
+  constructor(
+    @Inject(OLLAMA_CLIENT) private readonly ollama: Ollama,
+    private readonly configService: ConfigService,
+  ) {
+    this.embedModel = this.configService.get<string>(
+      'OLLAMA_EMBED_MODEL',
+      'all-minilm',
+    );
+  }
+
+  async embed(text: string): Promise<number[]> {
+    const response = await this.ollama.embed({
+      model: this.embedModel,
+      input: text,
+    });
+    return response.embeddings?.[0] ?? [];
+  }
+
+  async embedBatch(texts: string[]): Promise<number[][]> {
+    if (texts.length === 0) {
+      return [];
+    }
+
+    const response = await this.ollama.embed({
+      model: this.embedModel,
+      input: texts,
+    });
+
+    return response.embeddings ?? [];
+  }
+}

--- a/backend/src/inference/providers/ollama/ollama-provider.module.ts
+++ b/backend/src/inference/providers/ollama/ollama-provider.module.ts
@@ -2,9 +2,11 @@ import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { CHAT_COMPLETION_PORT } from '../../ports/chat-completion.port';
 import { CLASSIFICATION_PORT } from '../../ports/classification.port';
+import { EMBEDDING_PORT } from '../../ports/embedding.port';
 import { ollamaClientProvider } from './ollama-client.provider';
 import { OllamaChatCompletionAdapter } from './ollama-chat-completion.adapter';
 import { OllamaClassificationAdapter } from './ollama-classification.adapter';
+import { OllamaEmbeddingAdapter } from './ollama-embedding.adapter';
 
 @Module({
   imports: [ConfigModule],
@@ -12,6 +14,7 @@ import { OllamaClassificationAdapter } from './ollama-classification.adapter';
     ollamaClientProvider,
     OllamaChatCompletionAdapter,
     OllamaClassificationAdapter,
+    OllamaEmbeddingAdapter,
     {
       provide: CHAT_COMPLETION_PORT,
       useExisting: OllamaChatCompletionAdapter,
@@ -20,7 +23,11 @@ import { OllamaClassificationAdapter } from './ollama-classification.adapter';
       provide: CLASSIFICATION_PORT,
       useExisting: OllamaClassificationAdapter,
     },
+    {
+      provide: EMBEDDING_PORT,
+      useExisting: OllamaEmbeddingAdapter,
+    },
   ],
-  exports: [CHAT_COMPLETION_PORT, CLASSIFICATION_PORT],
+  exports: [CHAT_COMPLETION_PORT, CLASSIFICATION_PORT, EMBEDDING_PORT],
 })
 export class OllamaProviderModule {}

--- a/backend/src/infrastructure/vector-store/qdrant-client.provider.ts
+++ b/backend/src/infrastructure/vector-store/qdrant-client.provider.ts
@@ -1,0 +1,14 @@
+import { Provider } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { QdrantClient } from '@qdrant/js-client-rest';
+
+export const QDRANT_CLIENT = Symbol('QdrantClient');
+
+export const qdrantClientProvider: Provider = {
+  provide: QDRANT_CLIENT,
+  inject: [ConfigService],
+  useFactory: (configService: ConfigService) =>
+    new QdrantClient({
+      url: configService.get<string>('QDRANT_URL', 'http://127.0.0.1:6333'),
+    }),
+};

--- a/backend/src/infrastructure/vector-store/qdrant-vector-store.adapter.spec.ts
+++ b/backend/src/infrastructure/vector-store/qdrant-vector-store.adapter.spec.ts
@@ -1,0 +1,130 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { QdrantVectorStoreAdapter } from './qdrant-vector-store.adapter';
+import { QDRANT_CLIENT } from './qdrant-client.provider';
+
+const mockQdrantClient = {
+  getCollection: jest.fn(),
+  createCollection: jest.fn(),
+  createPayloadIndex: jest.fn(),
+  upsert: jest.fn(),
+  search: jest.fn(),
+  retrieve: jest.fn(),
+  delete: jest.fn(),
+};
+
+describe('QdrantVectorStoreAdapter', () => {
+  let adapter: QdrantVectorStoreAdapter;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        QdrantVectorStoreAdapter,
+        { provide: QDRANT_CLIENT, useValue: mockQdrantClient },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string, fallback: string) => fallback),
+          },
+        },
+      ],
+    }).compile();
+
+    adapter = module.get<QdrantVectorStoreAdapter>(QdrantVectorStoreAdapter);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates collection and chatroom payload index when missing', async () => {
+    mockQdrantClient.getCollection.mockRejectedValue(new Error('not found'));
+
+    await adapter.onModuleInit();
+
+    expect(mockQdrantClient.createCollection).toHaveBeenCalledWith(
+      'chat_memory',
+      {
+        vectors: { size: 384, distance: 'Cosine' },
+      },
+    );
+    expect(mockQdrantClient.createPayloadIndex).toHaveBeenCalledWith(
+      'chat_memory',
+      {
+        field_name: 'chatroomId',
+        field_schema: 'integer',
+      },
+    );
+  });
+
+  it('builds search filters with chatroom and exclusions', async () => {
+    mockQdrantClient.search.mockResolvedValue([
+      {
+        id: '1',
+        score: 0.9,
+        payload: {
+          chatroomId: 1,
+          userId: '1',
+          messageId: '1',
+          createdAt: '2026-04-12T00:00:00.000Z',
+          sender: 'user',
+          content: 'context',
+        },
+      },
+    ]);
+
+    const results = await adapter.search({
+      vector: [0.1, 0.2],
+      limit: 5,
+      minScore: 0.4,
+      chatroomId: 11,
+      excludeMessageIds: ['3', '5'],
+    });
+
+    expect(results).toHaveLength(1);
+    expect(mockQdrantClient.search).toHaveBeenCalledWith(
+      'chat_memory',
+      expect.objectContaining({
+        filter: {
+          must: [{ key: 'chatroomId', match: { value: 11 } }],
+          must_not: [{ key: 'messageId', match: { any: ['3', '5'] } }],
+        },
+      }),
+    );
+  });
+
+  it('normalizes numeric string id for upsert', async () => {
+    await adapter.upsert({
+      id: '481',
+      vector: [0.1, 0.2],
+      payload: {
+        chatroomId: 1,
+        userId: '1',
+        messageId: '481',
+        createdAt: '2026-04-12T00:00:00.000Z',
+        sender: 'user',
+        content: 'context',
+      },
+    });
+
+    expect(mockQdrantClient.upsert).toHaveBeenCalledWith(
+      'chat_memory',
+      expect.objectContaining({
+        points: [expect.objectContaining({ id: 481 })],
+      }),
+    );
+  });
+
+  it('normalizes numeric string id for retrieve', async () => {
+    mockQdrantClient.retrieve.mockResolvedValue([]);
+
+    await adapter.hasPoint('482');
+
+    expect(mockQdrantClient.retrieve).toHaveBeenCalledWith(
+      'chat_memory',
+      expect.objectContaining({
+        ids: [482],
+      }),
+    );
+  });
+});

--- a/backend/src/infrastructure/vector-store/qdrant-vector-store.adapter.ts
+++ b/backend/src/infrastructure/vector-store/qdrant-vector-store.adapter.ts
@@ -1,0 +1,111 @@
+import {
+  Inject,
+  Injectable,
+  Logger,
+  OnModuleInit,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { QdrantClient } from '@qdrant/js-client-rest';
+import {
+  VectorSearchRequest,
+  VectorSearchResult,
+  VectorStorePort,
+  type VectorPoint,
+} from './vector-store.port';
+import { QDRANT_CLIENT } from './qdrant-client.provider';
+
+@Injectable()
+export class QdrantVectorStoreAdapter implements VectorStorePort, OnModuleInit {
+  private readonly logger = new Logger(QdrantVectorStoreAdapter.name);
+  private readonly collectionName: string;
+  private static readonly INTEGER_ID_PATTERN = /^\d+$/;
+
+  constructor(
+    @Inject(QDRANT_CLIENT) private readonly qdrantClient: QdrantClient,
+    private readonly configService: ConfigService,
+  ) {
+    this.collectionName = this.configService.get<string>(
+      'QDRANT_COLLECTION',
+      'chat_memory',
+    );
+  }
+
+  async onModuleInit(): Promise<void> {
+    try {
+      await this.qdrantClient.getCollection(this.collectionName);
+    } catch {
+      await this.qdrantClient.createCollection(this.collectionName, {
+        vectors: { size: 384, distance: 'Cosine' },
+      });
+      await this.qdrantClient.createPayloadIndex(this.collectionName, {
+        field_name: 'chatroomId',
+        field_schema: 'integer',
+      });
+      this.logger.log(`Created Qdrant collection: ${this.collectionName}`);
+    }
+  }
+
+  async upsert(point: VectorPoint): Promise<void> {
+    const normalizedId = this.normalizePointId(point.id);
+    await this.qdrantClient.upsert(this.collectionName, {
+      wait: false,
+      points: [{ ...point, id: normalizedId }],
+    });
+  }
+
+  async search(req: VectorSearchRequest): Promise<VectorSearchResult[]> {
+    const results = await this.qdrantClient.search(this.collectionName, {
+      vector: req.vector,
+      limit: req.limit,
+      score_threshold: req.minScore,
+      with_payload: true,
+      filter: {
+        must: [{ key: 'chatroomId', match: { value: req.chatroomId } }],
+        must_not:
+          req.excludeMessageIds && req.excludeMessageIds.length > 0
+            ? [{ key: 'messageId', match: { any: req.excludeMessageIds } }]
+            : undefined,
+      },
+    });
+
+    return results
+      .filter((result) => result.payload != null)
+      .map((result) => ({
+        id: String(result.id),
+        score: result.score ?? 0,
+        payload: result.payload as VectorSearchResult['payload'],
+      }));
+  }
+
+  async hasPoint(id: string): Promise<boolean> {
+    const normalizedId = this.normalizePointId(id);
+    const points = await this.qdrantClient.retrieve(this.collectionName, {
+      ids: [normalizedId],
+      with_payload: false,
+      with_vector: false,
+    });
+    return points.length > 0;
+  }
+
+  async deleteByChatroom(chatroomId: number): Promise<void> {
+    try {
+      await this.qdrantClient.delete(this.collectionName, {
+        wait: false,
+        filter: {
+          must: [{ key: 'chatroomId', match: { value: chatroomId } }],
+        },
+      });
+    } catch (error) {
+      this.logger.error('Failed to delete vectors by chatroom', error);
+      throw new ServiceUnavailableException('Vector store delete failed');
+    }
+  }
+
+  private normalizePointId(id: string): string | number {
+    if (QdrantVectorStoreAdapter.INTEGER_ID_PATTERN.test(id)) {
+      return Number(id);
+    }
+    return id;
+  }
+}

--- a/backend/src/infrastructure/vector-store/vector-store.module.ts
+++ b/backend/src/infrastructure/vector-store/vector-store.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { qdrantClientProvider } from './qdrant-client.provider';
+import { QdrantVectorStoreAdapter } from './qdrant-vector-store.adapter';
+import { VECTOR_STORE_PORT } from './vector-store.port';
+
+@Module({
+  imports: [ConfigModule],
+  providers: [
+    qdrantClientProvider,
+    QdrantVectorStoreAdapter,
+    {
+      provide: VECTOR_STORE_PORT,
+      useExisting: QdrantVectorStoreAdapter,
+    },
+  ],
+  exports: [VECTOR_STORE_PORT],
+})
+export class VectorStoreModule {}

--- a/backend/src/infrastructure/vector-store/vector-store.port.ts
+++ b/backend/src/infrastructure/vector-store/vector-store.port.ts
@@ -1,0 +1,37 @@
+export const VECTOR_STORE_PORT = Symbol('VectorStorePort');
+
+export type VectorPointPayload = {
+  chatroomId: number;
+  userId: string;
+  messageId: string;
+  createdAt: string;
+  sender: 'user' | 'ai';
+  content: string;
+};
+
+export type VectorPoint = {
+  id: string;
+  vector: number[];
+  payload: VectorPointPayload;
+};
+
+export type VectorSearchRequest = {
+  vector: number[];
+  limit: number;
+  minScore?: number;
+  chatroomId: number;
+  excludeMessageIds?: string[];
+};
+
+export type VectorSearchResult = {
+  id: string;
+  score: number;
+  payload: VectorPointPayload;
+};
+
+export interface VectorStorePort {
+  upsert(point: VectorPoint): Promise<void>;
+  search(req: VectorSearchRequest): Promise<VectorSearchResult[]>;
+  hasPoint(id: string): Promise<boolean>;
+  deleteByChatroom(chatroomId: number): Promise<void>;
+}

--- a/backend/src/messages/memory/memory.formatter.ts
+++ b/backend/src/messages/memory/memory.formatter.ts
@@ -1,0 +1,22 @@
+export type MemorySnippet = {
+  messageId: string;
+  content: string;
+  createdAt: string;
+  score: number;
+};
+
+export function formatMemorySnippets(snippets: MemorySnippet[]): string {
+  if (snippets.length === 0) {
+    return '';
+  }
+
+  const lines = snippets.map((snippet) => {
+    const date = snippet.createdAt.slice(0, 10);
+    return `- (${date}) "${snippet.content}"`;
+  });
+
+  return [
+    '## Relevant earlier context (do not repeat verbatim):',
+    ...lines,
+  ].join('\n');
+}

--- a/backend/src/messages/memory/memory.module.ts
+++ b/backend/src/messages/memory/memory.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { InferenceModule } from '../../inference/inference.module';
+import { PrismaModule } from '../../prisma/prisma.module';
+import { VectorStoreModule } from '../../infrastructure/vector-store/vector-store.module';
+import { MemoryService } from './memory.service';
+
+@Module({
+  imports: [InferenceModule, VectorStoreModule, PrismaModule],
+  providers: [MemoryService],
+  exports: [MemoryService],
+})
+export class MemoryModule {}

--- a/backend/src/messages/memory/memory.service.spec.ts
+++ b/backend/src/messages/memory/memory.service.spec.ts
@@ -1,0 +1,125 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { PrismaService } from '../../prisma/prisma.service';
+import { EMBEDDING_PORT } from '../../inference/ports/embedding.port';
+import { VECTOR_STORE_PORT } from '../../infrastructure/vector-store/vector-store.port';
+import { MemoryService } from './memory.service';
+
+const mockEmbeddingPort = {
+  embed: jest.fn(),
+};
+
+const mockVectorStorePort = {
+  upsert: jest.fn(),
+  search: jest.fn(),
+  hasPoint: jest.fn(),
+};
+
+const mockPrismaService = {
+  message: {
+    findFirst: jest.fn(),
+  },
+};
+
+describe('MemoryService', () => {
+  let service: MemoryService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MemoryService,
+        { provide: EMBEDDING_PORT, useValue: mockEmbeddingPort },
+        { provide: VECTOR_STORE_PORT, useValue: mockVectorStorePort },
+        { provide: PrismaService, useValue: mockPrismaService },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string, fallback: number) => fallback),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<MemoryService>(MemoryService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('skips indexing when target older message is not from user', async () => {
+    mockPrismaService.message.findFirst.mockResolvedValue({
+      id: 21n,
+      sender: 'ai',
+      content: 'ai note',
+      createdAt: new Date(),
+      chatroom: { userId: 1n },
+    });
+
+    await service.indexOlderMessage(1);
+
+    expect(mockEmbeddingPort.embed).not.toHaveBeenCalled();
+    expect(mockVectorStorePort.upsert).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent when vector point already exists', async () => {
+    mockPrismaService.message.findFirst.mockResolvedValue({
+      id: 22n,
+      sender: 'user',
+      content: 'older user message',
+      createdAt: new Date('2026-04-12T00:00:00.000Z'),
+      chatroom: { userId: 7n },
+    });
+    mockVectorStorePort.hasPoint.mockResolvedValue(true);
+
+    await service.indexOlderMessage(1);
+
+    expect(mockEmbeddingPort.embed).not.toHaveBeenCalled();
+    expect(mockVectorStorePort.upsert).not.toHaveBeenCalled();
+  });
+
+  it('retrieves and truncates memory snippets with score filtering handled by vector store', async () => {
+    mockEmbeddingPort.embed.mockResolvedValue([0.1, 0.2]);
+    mockVectorStorePort.search.mockResolvedValue([
+      {
+        id: '1',
+        score: 0.91,
+        payload: {
+          chatroomId: 1,
+          userId: '1',
+          messageId: '1',
+          createdAt: '2026-04-12T00:00:00.000Z',
+          sender: 'user',
+          content: 'x'.repeat(260),
+        },
+      },
+      {
+        id: '2',
+        score: 0.83,
+        payload: {
+          chatroomId: 1,
+          userId: '1',
+          messageId: '2',
+          createdAt: '2026-04-13T00:00:00.000Z',
+          sender: 'user',
+          content: 'short text',
+        },
+      },
+    ]);
+
+    const snippets = await service.retrieveContext(1, 'migration notes', {
+      k: 5,
+      recentMessageIds: ['9', '10'],
+    });
+
+    expect(mockVectorStorePort.search).toHaveBeenCalledWith({
+      vector: [0.1, 0.2],
+      limit: 5,
+      minScore: 0.4,
+      chatroomId: 1,
+      excludeMessageIds: ['9', '10'],
+    });
+    expect(snippets).toHaveLength(2);
+    expect(snippets[0].content.length).toBeLessThanOrEqual(200);
+  });
+});

--- a/backend/src/messages/memory/memory.service.ts
+++ b/backend/src/messages/memory/memory.service.ts
@@ -1,0 +1,155 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PrismaService } from '../../prisma/prisma.service';
+import {
+  EMBEDDING_PORT,
+  type EmbeddingPort,
+} from '../../inference/ports/embedding.port';
+import {
+  VECTOR_STORE_PORT,
+  type VectorStorePort,
+} from '../../infrastructure/vector-store/vector-store.port';
+import { MemorySnippet } from './memory.formatter';
+
+type RetrieveContextInput = {
+  k: number;
+  recentMessageIds: string[];
+};
+
+@Injectable()
+export class MemoryService {
+  private readonly logger = new Logger(MemoryService.name);
+  private readonly recentWindow: number;
+  private readonly minScore: number;
+  private readonly snippetChars: number;
+
+  constructor(
+    @Inject(EMBEDDING_PORT) private readonly embeddingPort: EmbeddingPort,
+    @Inject(VECTOR_STORE_PORT)
+    private readonly vectorStorePort: VectorStorePort,
+    private readonly prisma: PrismaService,
+    private readonly configService: ConfigService,
+  ) {
+    this.recentWindow = Number(this.configService.get('RAG_RECENT_WINDOW', 8));
+    this.minScore = Number(this.configService.get('RAG_MIN_SCORE', 0.4));
+    this.snippetChars = Number(
+      this.configService.get('RAG_SNIPPET_CHARS', 200),
+    );
+  }
+
+  async indexOlderMessage(chatroomId: number): Promise<void> {
+    this.logger.debug(
+      `Indexing older message candidate for chatroom=${chatroomId}, recentWindow=${this.recentWindow}`,
+    );
+    const olderMessage = await this.prisma.message.findFirst({
+      where: { chatroomId: BigInt(chatroomId) },
+      orderBy: { createdAt: 'desc' },
+      skip: this.recentWindow,
+      select: {
+        id: true,
+        sender: true,
+        content: true,
+        createdAt: true,
+        chatroom: {
+          select: {
+            userId: true,
+          },
+        },
+      },
+    });
+
+    if (!olderMessage) {
+      this.logger.debug(
+        `No older message to index for chatroom=${chatroomId} after skipping recent window`,
+      );
+      return;
+    }
+
+    if (olderMessage.sender !== 'user') {
+      this.logger.debug(
+        `Skipping index for message=${olderMessage.id.toString()} because sender=${olderMessage.sender}`,
+      );
+      return;
+    }
+
+    const pointId = olderMessage.id.toString();
+    const alreadyIndexed = await this.vectorStorePort.hasPoint(pointId);
+    if (alreadyIndexed) {
+      this.logger.debug(`Vector point already exists for message=${pointId}`);
+      return;
+    }
+
+    this.logger.debug(
+      `Embedding older message for index: message=${pointId}, contentLength=${olderMessage.content.length}`,
+    );
+    const embedding = await this.embeddingPort.embed(olderMessage.content);
+    if (embedding.length === 0) {
+      this.logger.warn(`Empty embedding for message ${pointId}`);
+      return;
+    }
+
+    await this.vectorStorePort.upsert({
+      id: pointId,
+      vector: embedding,
+      payload: {
+        chatroomId,
+        userId: olderMessage.chatroom.userId.toString(),
+        messageId: pointId,
+        createdAt: olderMessage.createdAt.toISOString(),
+        sender: 'user',
+        content: olderMessage.content,
+      },
+    });
+
+    this.logger.debug(
+      `Indexed message=${pointId} into vector store with embeddingDim=${embedding.length}`,
+    );
+  }
+
+  async retrieveContext(
+    chatroomId: number,
+    query: string,
+    opts: RetrieveContextInput,
+  ): Promise<MemorySnippet[]> {
+    const normalizedQuery = query.trim();
+    this.logger.debug(
+      `Retrieving memory context for chatroom=${chatroomId}, queryLength=${normalizedQuery.length}, k=${opts.k}, excludeCount=${opts.recentMessageIds.length}`,
+    );
+    if (!normalizedQuery) {
+      this.logger.debug('Skipping memory retrieval because query is empty');
+      return [];
+    }
+
+    const vector = await this.embeddingPort.embed(normalizedQuery);
+    if (vector.length === 0) {
+      this.logger.warn(
+        `Empty query embedding for chatroom=${chatroomId}; memory retrieval skipped`,
+      );
+      return [];
+    }
+
+    this.logger.debug(
+      `Searching vector store for chatroom=${chatroomId} with embeddingDim=${vector.length}, minScore=${this.minScore}`,
+    );
+    const results = await this.vectorStorePort.search({
+      vector,
+      limit: opts.k,
+      minScore: this.minScore,
+      chatroomId,
+      excludeMessageIds: opts.recentMessageIds,
+    });
+
+    this.logger.debug(
+      `Vector search returned ${results.length} candidates for chatroom=${chatroomId}`,
+    );
+
+    return results
+      .map((result) => ({
+        messageId: result.payload.messageId,
+        content: result.payload.content.slice(0, this.snippetChars),
+        createdAt: result.payload.createdAt,
+        score: result.score,
+      }))
+      .sort((a, b) => b.score - a.score);
+  }
+}

--- a/backend/src/messages/messages.module.ts
+++ b/backend/src/messages/messages.module.ts
@@ -10,9 +10,10 @@ import { MessageStreamService } from './message-stream.service';
 import { MessagesRepository } from './messages.repository';
 import { ChatroomStateRepository } from './chatroom-state.repository';
 import { InferenceModule } from '../inference/inference.module';
+import { MemoryModule } from './memory/memory.module';
 
 @Module({
-  imports: [PrismaModule, InferenceModule, NotificationsModule],
+  imports: [PrismaModule, InferenceModule, NotificationsModule, MemoryModule],
   providers: [
     MessagesService,
     MessagesGateway,

--- a/backend/src/messages/messages.service.spec.ts
+++ b/backend/src/messages/messages.service.spec.ts
@@ -7,6 +7,8 @@ import { MessageStreamService } from './message-stream.service';
 import { MessagesRepository } from './messages.repository';
 import { ChatroomStateRepository } from './chatroom-state.repository';
 import { FcmPushService } from '../notifications/fcm-push.service';
+import { MemoryService } from './memory/memory.service';
+import { ConfigService } from '@nestjs/config';
 import {
   NORMAL_CHAT_BASE_SYSTEM,
   STABLE_VOLUNTARY_ALIGNMENT,
@@ -34,6 +36,13 @@ const mockChatroomStateRepository = {
 const mockFcmPushService = {
   notifyProactiveAiMessage: jest.fn().mockResolvedValue(undefined),
 };
+const mockMemoryService = {
+  indexOlderMessage: jest.fn().mockResolvedValue(undefined),
+  retrieveContext: jest.fn().mockResolvedValue([]),
+};
+const mockConfigService = {
+  get: jest.fn((key: string, fallback: number) => fallback),
+};
 
 describe('MessagesService', () => {
   let service: MessagesService;
@@ -55,6 +64,8 @@ describe('MessagesService', () => {
           useValue: mockChatroomStateRepository,
         },
         { provide: FcmPushService, useValue: mockFcmPushService },
+        { provide: MemoryService, useValue: mockMemoryService },
+        { provide: ConfigService, useValue: mockConfigService },
       ],
     }).compile();
 
@@ -64,6 +75,11 @@ describe('MessagesService', () => {
   afterEach(() => {
     jest.clearAllMocks();
     mockFcmPushService.notifyProactiveAiMessage.mockResolvedValue(undefined);
+    mockMemoryService.retrieveContext.mockResolvedValue([]);
+    mockMemoryService.indexOlderMessage.mockResolvedValue(undefined);
+    mockConfigService.get.mockImplementation(
+      (key: string, fallback: number) => fallback,
+    );
   });
 
   it('should be defined', () => {
@@ -117,6 +133,7 @@ describe('MessagesService', () => {
     expect(
       mockChatroomStateRepository.clearNextEvaluationTime,
     ).toHaveBeenCalledWith(1n);
+    expect(mockMemoryService.indexOlderMessage).toHaveBeenCalledWith(1);
     expect(processMock).toHaveBeenCalledWith(1);
 
     processMock.mockRestore();
@@ -297,6 +314,57 @@ describe('MessagesService', () => {
       expect.any(Function),
       undefined,
     );
+  });
+
+  it('adds retrieved memory block into system prompt before generation', async () => {
+    mockConfigService.get.mockImplementation(
+      (key: string, fallback: number) => {
+        if (key === 'RAG_TOP_K') {
+          return 5;
+        }
+        return fallback;
+      },
+    );
+    mockChatroomStateRepository.findById.mockResolvedValue({
+      id: 1n,
+      userId: 2n,
+      name: 'Room',
+      basePrompt: 'You are helpful.',
+    });
+    mockMessagesRepository.findRecent.mockResolvedValue([
+      {
+        id: 11n,
+        chatroomId: 1n,
+        sender: 'user',
+        content: 'remind me about postgres migration',
+        createdAt: new Date('2026-04-12T10:00:00.000Z'),
+      },
+    ]);
+    mockMemoryService.retrieveContext.mockResolvedValue([
+      {
+        messageId: '7',
+        content: 'You previously said to run prisma migrate deploy in CI.',
+        createdAt: '2026-04-12T00:00:00.000Z',
+        score: 0.91,
+      },
+    ]);
+    mockChatGenerationService.generate.mockResolvedValue('reply');
+    mockMessagesRepository.createMessage.mockResolvedValue({ id: 1n });
+    mockChatroomStateRepository.resetDelay.mockResolvedValue(undefined);
+
+    await service.processBackgroundMessage(1, false);
+
+    expect(mockMemoryService.retrieveContext).toHaveBeenCalledWith(
+      1,
+      'remind me about postgres migration',
+      { k: 5, recentMessageIds: ['11'] },
+    );
+    const systemPrompt = (
+      mockChatGenerationService.generate.mock.calls[0] as [unknown, string]
+    )[1];
+    expect(systemPrompt).toContain(NORMAL_CHAT_BASE_SYSTEM);
+    expect(systemPrompt).toContain('## Relevant earlier context');
+    expect(systemPrompt).toContain('prisma migrate deploy');
   });
 
   it('should use only the normal base system prompt when room basePrompt is empty', async () => {

--- a/backend/src/messages/messages.service.ts
+++ b/backend/src/messages/messages.service.ts
@@ -13,6 +13,12 @@ import {
 } from '../inference/prompts/chat-system.prompt';
 import { toChatHistory } from '../inference/shared/chat-history.util';
 import { ChatGenerationService } from '../inference/tasks/chat-generation.service';
+import { MemoryService } from './memory/memory.service';
+import { formatMemorySnippets } from './memory/memory.formatter';
+import { ConfigService } from '@nestjs/config';
+
+const PROACTIVE_HISTORY_WINDOW_SIZE = 5;
+const DEFAULT_HISTORY_WINDOW_SIZE = 8;
 
 @Injectable()
 export class MessagesService {
@@ -26,6 +32,8 @@ export class MessagesService {
     private readonly messagesRepository: MessagesRepository,
     private readonly chatroomStateRepository: ChatroomStateRepository,
     private readonly fcmPushService: FcmPushService,
+    private readonly memoryService: MemoryService,
+    private readonly configService: ConfigService,
   ) {}
 
   async findHistory(
@@ -47,6 +55,9 @@ export class MessagesService {
     await this.chatroomStateRepository.clearNextEvaluationTime(
       BigInt(chatroomId),
     );
+    this.memoryService.indexOlderMessage(chatroomId).catch((err) => {
+      this.logger.warn('Memory indexing failed', err);
+    });
 
     this.processBackgroundMessage(chatroomId).catch((err) => {
       this.logger.error('Background processing failed', err);
@@ -60,6 +71,7 @@ export class MessagesService {
 
   public async processBackgroundMessage(chatroomId: number, proactive = false) {
     try {
+      const ragTopK = Number(this.configService.get('RAG_TOP_K', 5));
       const chatRoomIdBigInt = BigInt(chatroomId);
       const room =
         await this.chatroomStateRepository.findById(chatRoomIdBigInt);
@@ -79,9 +91,35 @@ export class MessagesService {
 
       const historyRaw = await this.messagesRepository.findRecent(
         chatRoomIdBigInt,
-        proactive ? 5 : 8,
+        proactive ? PROACTIVE_HISTORY_WINDOW_SIZE : DEFAULT_HISTORY_WINDOW_SIZE,
+      );
+      this.logger.debug(
+        `Loaded ${historyRaw.length} recent messages for chatroom=${chatroomId} (proactive=${proactive})`,
       );
       const history = toChatHistory(historyRaw);
+      const recentMessageIds = historyRaw.map((message) =>
+        message.id.toString(),
+      );
+      const queryMessage = [...history]
+        .reverse()
+        .find((message) => message.role === 'user');
+      const memorySnippets = queryMessage
+        ? await this.memoryService.retrieveContext(
+            chatroomId,
+            queryMessage.content,
+            {
+              k: ragTopK,
+              recentMessageIds,
+            },
+          )
+        : [];
+      this.logger.debug(
+        `Retrieved ${memorySnippets.length} memory snippets for chatroom=${chatroomId}`,
+      );
+      const memoryBlock = formatMemorySnippets(memorySnippets);
+      const resolvedSystemPrompt = memoryBlock
+        ? `${systemPrompt}\n\n${memoryBlock}`
+        : systemPrompt;
 
       if (proactive) {
         const lastContent = history[history.length - 1]?.content ?? '';
@@ -94,7 +132,7 @@ export class MessagesService {
       this.messageStreamService.setTyping(chatroomId, true);
       const fullContent = await this.chatGenerationService.generate(
         history,
-        systemPrompt,
+        resolvedSystemPrompt,
         (chunk) => this.messageStreamService.streamChunk(chatroomId, chunk),
         proactive ? { proactive: true } : undefined,
       );

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -33,6 +33,13 @@ services:
       OLLAMA_HOST: ${OLLAMA_HOST}
       OLLAMA_CHAT_MODEL: ${OLLAMA_CHAT_MODEL}
       OLLAMA_EVAL_MODEL: ${OLLAMA_EVAL_MODEL}
+      OLLAMA_EMBED_MODEL: ${OLLAMA_EMBED_MODEL}
+      QDRANT_URL: ${QDRANT_URL}
+      QDRANT_COLLECTION: ${QDRANT_COLLECTION}
+      RAG_RECENT_WINDOW: ${RAG_RECENT_WINDOW:-8}
+      RAG_TOP_K: ${RAG_TOP_K:-5}
+      RAG_MIN_SCORE: ${RAG_MIN_SCORE:-0.4}
+      RAG_SNIPPET_CHARS: ${RAG_SNIPPET_CHARS:-200}
       PORT: "8080"
       ASSETS_DIR: /app/assets
       FIREBASE_SERVICE_ACCOUNT_JSON: ${FIREBASE_SERVICE_ACCOUNT_JSON:-}
@@ -45,6 +52,12 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
 
+  qdrant:
+    image: qdrant/qdrant:v1.12.4
+    restart: unless-stopped
+    volumes:
+      - qdrant_data:/qdrant/storage
+
   nginx:
     image: ${NGINX_IMAGE}:${IMAGE_TAG}
     restart: unless-stopped
@@ -56,3 +69,4 @@ services:
 volumes:
   mysql_data:
   backend_assets:
+  qdrant_data:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -33,6 +33,13 @@ services:
       OLLAMA_HOST: ${OLLAMA_HOST:-http://host.docker.internal:11434}
       OLLAMA_CHAT_MODEL: ${OLLAMA_CHAT_MODEL:-qwen2.5:1.5b}
       OLLAMA_EVAL_MODEL: ${OLLAMA_EVAL_MODEL:-qwen2.5:1.5b}
+      OLLAMA_EMBED_MODEL: ${OLLAMA_EMBED_MODEL:-all-minilm}
+      QDRANT_URL: ${QDRANT_URL:-http://qdrant:6333}
+      QDRANT_COLLECTION: ${QDRANT_COLLECTION:-chat_memory}
+      RAG_RECENT_WINDOW: ${RAG_RECENT_WINDOW:-8}
+      RAG_TOP_K: ${RAG_TOP_K:-5}
+      RAG_MIN_SCORE: ${RAG_MIN_SCORE:-0.4}
+      RAG_SNIPPET_CHARS: ${RAG_SNIPPET_CHARS:-200}
       PORT: "8080"
       ASSETS_DIR: /app/assets
       FIREBASE_SERVICE_ACCOUNT_JSON: ${FIREBASE_SERVICE_ACCOUNT_JSON:-}
@@ -44,6 +51,15 @@ services:
         condition: service_healthy
     extra_hosts:
       - "host.docker.internal:host-gateway"
+
+  qdrant:
+    image: qdrant/qdrant:v1.12.4
+    restart: unless-stopped
+    ports:
+      - "${QDRANT_HTTP_PORT:-6333}:6333"
+      - "${QDRANT_GRPC_PORT:-6334}:6334"
+    volumes:
+      - qdrant_data:/qdrant/storage
 
   nginx:
     build:
@@ -66,3 +82,4 @@ services:
 volumes:
   mysql_data:
   backend_assets:
+  qdrant_data:


### PR DESCRIPTION
## Summary
- add an embedding port/adapter and wire Ollama embedding support into the inference provider module
- add a Qdrant vector-store module and memory service to index older chat messages and retrieve relevant long-term context
- append retrieved memory snippets to message-generation system prompts, and update docker/env/docs to run Qdrant and configure RAG behavior

## Test plan
- [x] backend unit tests for Ollama embedding adapter
- [x] backend unit tests for Qdrant vector-store adapter
- [x] backend unit tests for memory service and message prompt memory injection
- [ ] backend: `npm run test`
- [ ] backend: `npm run lint`

Made with [Cursor](https://cursor.com)