### PR TITLE
chore(release): promote develop to main

### DIFF
--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -55,6 +55,9 @@ services:
   qdrant:
     image: qdrant/qdrant:v1.12.4
     restart: unless-stopped
+    ports:
+      - "${QDRANT_HTTP_PORT:-6333}:6333"
+      - "${QDRANT_GRPC_PORT:-6334}:6334"
     volumes:
       - qdrant_data:/qdrant/storage
 


### PR DESCRIPTION
## Summary

- Promotes `develop` to `main`, including `chore: open qdrant to host` (Qdrant host exposure in deploy config).

## Why

- Ship the latest integration work to the production branch.

## Test plan

- [ ] backend: `npm run lint`
- [ ] backend: `npm run test`
- [ ] frontend: `npm run lint`
- [ ] frontend: `npm run typecheck`
- [ ] frontend: `npm run test`

## Rollback notes

- Revert the merge commit on `main` if a production issue appears; back-merge or cherry-pick fixes into `develop` per hotfix flow.

Made with [Cursor](https://cursor.com)