### PR TITLE
fix(frontend): stabilize PWA navigation and HTTPS dev setup

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,5 +1,8 @@
 # Backend API URL (no trailing slash)
 VITE_API_URL=http://localhost:8080
+# Optional: proxy backend through Vite dev server to avoid CORS (works with cloudflared/mobile)
+# Example: VITE_DEV_PROXY_TARGET=http://127.0.0.1:8081
+VITE_DEV_PROXY_TARGET=
 
 # Firebase Web app config (Firebase Console → Project settings → Your apps)
 VITE_FIREBASE_API_KEY=

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -24,3 +24,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+certs

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -37,6 +37,45 @@ Edit `.env`:
 npm run dev
 ```
 
+## Local HTTPS for mobile PWA testing
+
+If you open the app from your phone via `http://<LAN-IP>:5173`, browsers treat it as insecure and block PWA installability.
+Use local HTTPS instead:
+
+1. Install `mkcert` and its local CA on your Mac:
+
+```bash
+brew install mkcert
+mkcert -install
+```
+
+2. Create certs in `frontend/certs` (replace `<LAN-IP>` with your machine IP, for example `192.168.0.12`):
+
+```bash
+mkdir -p certs
+mkcert -key-file certs/localhost-key.pem -cert-file certs/localhost.pem localhost 127.0.0.1 ::1 <LAN-IP>
+```
+
+3. Run Vite with HTTPS:
+
+```bash
+npm run dev:https
+```
+
+4. Open from mobile:
+
+```text
+https://<LAN-IP>:5173
+```
+
+Optional `.env` overrides if your cert files live elsewhere:
+
+```bash
+VITE_HTTPS=true
+VITE_HTTPS_CERT=./path/to/cert.pem
+VITE_HTTPS_KEY=./path/to/key.pem
+```
+
 Production build and preview:
 
 ```bash
@@ -51,12 +90,15 @@ npm run preview
 | `VITE_API_URL`                              | REST + Socket.IO base (same host/path the browser uses to reach the API). |
 | `VITE_FIREBASE_*`                           | Firebase web app config for FCM.                                          |
 | `VITE_FCM_VAPID_KEY`                        | Web Push VAPID key from Firebase Console.                                 |
+| `VITE_HTTPS`                                | Set `true` to enable local HTTPS in Vite dev server.                      |
+| `VITE_HTTPS_CERT`, `VITE_HTTPS_KEY`         | Optional cert/key paths (defaults to `./certs/localhost.pem` and `./certs/localhost-key.pem`). |
 | `VITE_RELEASE_SHA`, `VITE_RELEASE_BUILT_AT` | Optional build metadata (e.g. CI).                                        |
 
 ## Scripts
 
 ```bash
 npm run dev                 # Vite dev server (--host)
+npm run dev:https           # Vite dev server with local HTTPS cert/key
 npm run build               # tsc -b && vite build
 npm run preview             # Preview production build
 npm run lint                # ESLint

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -31,6 +31,7 @@ cp .env.example .env
 Edit `.env`:
 
 - **`VITE_API_URL`** — backend origin, **no trailing slash** (e.g. `http://localhost:8080` for local Nest with default `PORT`).
+- **`VITE_DEV_PROXY_TARGET`** — optional dev-only proxy target to avoid CORS (e.g. `http://127.0.0.1:8081`).
 - **Firebase / `VITE_FCM_VAPID_KEY`** — optional; omit for local UI flows without push.
 
 ```bash
@@ -76,6 +77,14 @@ VITE_HTTPS_CERT=./path/to/cert.pem
 VITE_HTTPS_KEY=./path/to/key.pem
 ```
 
+For Cloudflare tunnel + mobile testing, you can also route API and Socket.IO through Vite to avoid backend CORS:
+
+```bash
+VITE_DEV_PROXY_TARGET=http://127.0.0.1:8081
+```
+
+When this is set in dev mode, frontend uses same-origin `/api` and `/socket.io`, and Vite proxies to the backend target.
+
 Production build and preview:
 
 ```bash
@@ -88,6 +97,7 @@ npm run preview
 | Variable                                    | Purpose                                                                   |
 | ------------------------------------------- | ------------------------------------------------------------------------- |
 | `VITE_API_URL`                              | REST + Socket.IO base (same host/path the browser uses to reach the API). |
+| `VITE_DEV_PROXY_TARGET`                     | Optional dev-only backend proxy target for `/api` and `/socket.io` to avoid CORS. |
 | `VITE_FIREBASE_*`                           | Firebase web app config for FCM.                                          |
 | `VITE_FCM_VAPID_KEY`                        | Web Push VAPID key from Firebase Console.                                 |
 | `VITE_HTTPS`                                | Set `true` to enable local HTTPS in Vite dev server.                      |

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite --host",
+    "dev:https": "VITE_HTTPS=true vite --host",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "typecheck": "tsc -b --pretty false",

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -3,7 +3,9 @@ import { queryClient } from '../app/providers/queryClient'
 import { clearAuth, getAccessToken } from '../shared/lib/auth'
 import { notifySessionExpired } from '../shared/lib/sessionExpired'
 
-const baseURL = import.meta.env.VITE_API_URL + '/api'
+const useDevProxy = import.meta.env.DEV && (import.meta.env.VITE_DEV_PROXY_TARGET?.trim()?.length ?? 0) > 0
+const apiOrigin = import.meta.env.VITE_API_URL?.trim()
+const baseURL = useDevProxy ? '/api' : `${apiOrigin}/api`
 const DEV_API_DELAY_MS = 1500
 
 function isAuthLoginRequest(config: InternalAxiosRequestConfig | undefined): boolean {

--- a/frontend/src/features/chatroom/hooks/useWebSocketStream.ts
+++ b/frontend/src/features/chatroom/hooks/useWebSocketStream.ts
@@ -4,7 +4,8 @@ import { io, Socket } from 'socket.io-client'
 import { getMessagesQueryKey } from '../queryKeys'
 import type { Message } from '../../../types/api'
 
-const WS_URL = import.meta.env.VITE_API_URL
+const useDevProxy = import.meta.env.DEV && (import.meta.env.VITE_DEV_PROXY_TARGET?.trim()?.length ?? 0) > 0
+const WS_URL = useDevProxy ? undefined : import.meta.env.VITE_API_URL?.trim()
 
 export const STREAMING_MESSAGE_ID = Number.MAX_SAFE_INTEGER
 
@@ -54,6 +55,7 @@ export const useWebSocketStream = (chatroomId: number) => {
     if (!chatroomId || socketRef.current?.connected) return
 
     const socket = io(WS_URL, {
+      path: '/socket.io',
       transports: ['websocket'],
     })
     const handleAnySocketEvent = (eventName: string, ...args: unknown[]) => {

--- a/frontend/src/layout/DefaultLayout.test.tsx
+++ b/frontend/src/layout/DefaultLayout.test.tsx
@@ -4,10 +4,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const navigateSpy = vi.hoisted(() => vi.fn())
 const useFcmForegroundSpy = vi.hoisted(() => vi.fn())
 const useUIStoreSpy = vi.hoisted(() => vi.fn())
+const useStableBackNavigationSpy = vi.hoisted(() => vi.fn())
 const clearPopupSpy = vi.hoisted(() => vi.fn())
 const getPopupChatroomPathSpy = vi.hoisted(() => vi.fn())
 const toggleSidebarSpy = vi.hoisted(() => vi.fn())
 const setSidebarOpenSpy = vi.hoisted(() => vi.fn())
+const useBlockerSpy = vi.hoisted(() => vi.fn())
+const handlePopNavigationSpy = vi.hoisted(() => vi.fn())
 
 vi.mock('react-router', async () => {
   const actual = await vi.importActual<typeof import('react-router')>('react-router')
@@ -16,7 +19,7 @@ vi.mock('react-router', async () => {
     Link: ({ children }: { children: React.ReactNode }) => <a>{children}</a>,
     Outlet: () => <div>layout-outlet</div>,
     useNavigate: () => navigateSpy,
-    useBlocker: () => undefined,
+    useBlocker: useBlockerSpy,
   }
 })
 
@@ -24,6 +27,9 @@ vi.mock('../features/notifications/hooks/useFcmForeground', () => ({
   useFcmForeground: useFcmForegroundSpy,
 }))
 vi.mock('../shared/stores/uiStore', () => ({ useUIStore: useUIStoreSpy }))
+vi.mock('../shared/hooks/useStableBackNavigation', () => ({
+  useStableBackNavigation: useStableBackNavigationSpy,
+}))
 vi.mock('../features/chatrooms/components/SideBar', () => ({ default: () => <div>sidebar</div> }))
 vi.mock('../features/notifications/components/PushNotificationButton', () => ({
   default: () => <button>push</button>,
@@ -62,10 +68,16 @@ describe('DefaultLayout', () => {
     getPopupChatroomPathSpy.mockReset()
     toggleSidebarSpy.mockReset()
     setSidebarOpenSpy.mockReset()
+    useBlockerSpy.mockReset()
+    handlePopNavigationSpy.mockReset()
     useFcmForegroundSpy.mockReturnValue({
       popup: { title: 'AI', body: 'Hi' },
       clearPopup: clearPopupSpy,
       getPopupChatroomPath: getPopupChatroomPathSpy,
+    })
+    useStableBackNavigationSpy.mockReturnValue({
+      showExitHint: false,
+      handlePopNavigation: handlePopNavigationSpy,
     })
     useUIStoreSpy.mockImplementation((selector: (state: Record<string, unknown>) => unknown) =>
       selector({
@@ -104,5 +116,34 @@ describe('DefaultLayout', () => {
     render(<DefaultLayout />)
 
     expect(screen.queryByText(/sha:/i)).toBeNull()
+  })
+
+  it('shows exit hint when stable back navigation requests it', async () => {
+    useStableBackNavigationSpy.mockReturnValue({
+      showExitHint: true,
+      handlePopNavigation: handlePopNavigationSpy,
+    })
+    const DefaultLayout = await loadDefaultLayout()
+
+    render(<DefaultLayout />)
+
+    expect(screen.getByText('Press back again to exit')).toBeTruthy()
+  })
+
+  it('delegates POP navigation blocking to stable back navigation hook', async () => {
+    handlePopNavigationSpy.mockReturnValue(true)
+    const DefaultLayout = await loadDefaultLayout()
+
+    render(<DefaultLayout />)
+
+    const blockerHandler = useBlockerSpy.mock.calls[0]?.[0] as
+      | ((args: { historyAction: 'POP' | 'PUSH' | 'REPLACE' }) => boolean)
+      | undefined
+    expect(blockerHandler).toBeTruthy()
+
+    const shouldBlockPop = blockerHandler?.({ historyAction: 'POP' })
+
+    expect(handlePopNavigationSpy).toHaveBeenCalledTimes(1)
+    expect(shouldBlockPop).toBe(true)
   })
 })

--- a/frontend/src/layout/DefaultLayout.tsx
+++ b/frontend/src/layout/DefaultLayout.tsx
@@ -10,6 +10,7 @@ import ForegroundNotificationPopup from '../features/notifications/components/Fo
 import { useFcmForeground } from '../features/notifications/hooks/useFcmForeground'
 import { useUIStore } from '../shared/stores/uiStore'
 import GithubLink from '../shared/ui/GithubLink'
+import { useStableBackNavigation } from '../shared/hooks/useStableBackNavigation'
 
 const releaseSha = import.meta.env.VITE_RELEASE_SHA?.slice(0, 7)
 const releaseBuiltAtValue = import.meta.env.VITE_RELEASE_BUILT_AT
@@ -29,6 +30,10 @@ export default function DefaultLayout() {
   const isSidebarOpen = useUIStore((state) => state.isSidebarOpen)
   const toggleSidebar = useUIStore((state) => state.toggleSidebar)
   const setSidebarOpen = useUIStore((state) => state.setSidebarOpen)
+  const { showExitHint, handlePopNavigation } = useStableBackNavigation({
+    isSidebarOpen,
+    setSidebarOpen,
+  })
   const formattedBuiltAt = releaseBuiltAtValue ? formatReleaseBuiltAt(releaseBuiltAtValue) : null
   const releaseLabel = releaseSha && formattedBuiltAt ? `${releaseSha} • ${formattedBuiltAt}` : null
 
@@ -48,11 +53,16 @@ export default function DefaultLayout() {
   }
 
   useBlocker(({ historyAction }) => {
-    if (historyAction === 'PUSH' || historyAction === 'REPLACE') {
-      setSidebarOpen(false)
-      return false
+    switch (historyAction) {
+      case 'PUSH':
+      case 'REPLACE':
+        setSidebarOpen(false)
+        return false
+      case 'POP':
+        return handlePopNavigation()
+      default:
+        return false
     }
-    return true
   })
 
   return (
@@ -67,6 +77,13 @@ export default function DefaultLayout() {
         onClick={handlePopupClick}
         onClose={clearPopup}
       />
+      {showExitHint ? (
+        <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-[60] pointer-events-none" aria-live="polite">
+          <div className="rounded-full bg-gray-900/95 text-white text-sm px-4 py-2 shadow-lg">
+            Press back again to exit
+          </div>
+        </div>
+      ) : null}
 
       {/* Sidebar */}
       <div

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -16,7 +16,7 @@ export default function HomePage() {
     useCreateChatroomFlow()
 
   if (fromLogin && !isLoading && !isError && sortedChatrooms.length > 0) {
-    return <Navigate to={ROUTES.CHATROOM(String(sortedChatrooms[0].id))} replace />
+    return <Navigate to={ROUTES.CHATROOM(String(sortedChatrooms[0].id))} />
   }
 
   return (

--- a/frontend/src/shared/hooks/useStableBackNavigation.test.tsx
+++ b/frontend/src/shared/hooks/useStableBackNavigation.test.tsx
@@ -1,0 +1,124 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useStableBackNavigation } from './useStableBackNavigation'
+
+function HookHarness({
+  isSidebarOpen = false,
+  setSidebarOpen = vi.fn(),
+}: {
+  isSidebarOpen?: boolean
+  setSidebarOpen?: (isOpen: boolean) => void
+}) {
+  const { showExitHint, handlePopNavigation } = useStableBackNavigation({
+    isSidebarOpen,
+    setSidebarOpen,
+  })
+
+  return (
+    <div>
+      <button
+        onClick={() => {
+          const shouldBlock = handlePopNavigation()
+          document.body.setAttribute('data-blocked', String(shouldBlock))
+        }}
+      >
+        trigger-pop
+      </button>
+      <span>{showExitHint ? 'hint-visible' : 'hint-hidden'}</span>
+    </div>
+  )
+}
+
+describe('useStableBackNavigation', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+    document.body.removeAttribute('data-blocked')
+  })
+
+  it('blocks first back at root and allows second back within exit window', () => {
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <Routes>
+          <Route path="/" element={<HookHarness />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    fireEvent.click(screen.getByText('trigger-pop'))
+    expect(document.body.getAttribute('data-blocked')).toBe('true')
+    expect(screen.getByText('hint-visible')).toBeTruthy()
+
+    fireEvent.click(screen.getByText('trigger-pop'))
+    expect(document.body.getAttribute('data-blocked')).toBe('false')
+    expect(screen.getByText('hint-hidden')).toBeTruthy()
+  })
+
+  it('allows normal POP navigation on non-root routes', () => {
+    render(
+      <MemoryRouter initialEntries={['/chat/1']}>
+        <Routes>
+          <Route path="/chat/:id" element={<HookHarness />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    fireEvent.click(screen.getByText('trigger-pop'))
+    expect(document.body.getAttribute('data-blocked')).toBe('false')
+    expect(screen.getByText('hint-hidden')).toBeTruthy()
+  })
+
+  it('closes sidebar first on mobile viewport and consumes back press', () => {
+    const setSidebarOpen = vi.fn()
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn().mockImplementation(() => ({
+        matches: true,
+        media: '(max-width: 767px)',
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    )
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <Routes>
+          <Route path="/" element={<HookHarness isSidebarOpen setSidebarOpen={setSidebarOpen} />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    fireEvent.click(screen.getByText('trigger-pop'))
+
+    expect(setSidebarOpen).toHaveBeenCalledWith(false)
+    expect(document.body.getAttribute('data-blocked')).toBe('true')
+  })
+
+  it('resets exit hint when timeout expires', () => {
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <Routes>
+          <Route path="/" element={<HookHarness />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    fireEvent.click(screen.getByText('trigger-pop'))
+    expect(screen.getByText('hint-visible')).toBeTruthy()
+
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+
+    expect(screen.getByText('hint-hidden')).toBeTruthy()
+  })
+})

--- a/frontend/src/shared/hooks/useStableBackNavigation.ts
+++ b/frontend/src/shared/hooks/useStableBackNavigation.ts
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useLocation } from 'react-router'
+import { ROUTES } from '../../routes/paths'
+
+const EXIT_WINDOW_MS = 2000
+const MOBILE_MEDIA_QUERY = '(max-width: 767px)'
+
+interface UseStableBackNavigationParams {
+  isSidebarOpen: boolean
+  setSidebarOpen: (isOpen: boolean) => void
+}
+
+interface UseStableBackNavigationResult {
+  showExitHint: boolean
+  handlePopNavigation: () => boolean
+}
+
+function isMobileViewport(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false
+  }
+  return window.matchMedia(MOBILE_MEDIA_QUERY).matches
+}
+
+export function useStableBackNavigation({
+  isSidebarOpen,
+  setSidebarOpen,
+}: UseStableBackNavigationParams): UseStableBackNavigationResult {
+  const location = useLocation()
+  const [showExitHint, setShowExitHint] = useState(false)
+  const [isExitArmed, setIsExitArmed] = useState(false)
+  const exitTimerRef = useRef<number | null>(null)
+
+  const clearExitTimer = useCallback(() => {
+    if (exitTimerRef.current !== null) {
+      window.clearTimeout(exitTimerRef.current)
+      exitTimerRef.current = null
+    }
+  }, [])
+
+  const resetExitState = useCallback(() => {
+    setIsExitArmed(false)
+    setShowExitHint(false)
+    clearExitTimer()
+  }, [clearExitTimer])
+
+  useEffect(() => clearExitTimer, [clearExitTimer])
+
+  const armExitWindow = useCallback(() => {
+    setIsExitArmed(true)
+    setShowExitHint(true)
+
+    if (exitTimerRef.current !== null) {
+      window.clearTimeout(exitTimerRef.current)
+    }
+
+    exitTimerRef.current = window.setTimeout(() => {
+      setIsExitArmed(false)
+      setShowExitHint(false)
+      exitTimerRef.current = null
+    }, EXIT_WINDOW_MS)
+  }, [])
+
+  const handlePopNavigation = useCallback(() => {
+    if (isSidebarOpen && isMobileViewport()) {
+      setSidebarOpen(false)
+      return true
+    }
+
+    if (location.pathname !== ROUTES.HOME) {
+      resetExitState()
+      return false
+    }
+
+    if (isExitArmed) {
+      resetExitState()
+      return false
+    }
+
+    armExitWindow()
+    return true
+  }, [armExitWindow, isExitArmed, isSidebarOpen, location.pathname, resetExitState, setSidebarOpen])
+
+  return {
+    showExitHint,
+    handlePopNavigation,
+  }
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -3,6 +3,7 @@
 
 interface ImportMetaEnv {
   readonly VITE_API_URL: string
+  readonly VITE_DEV_PROXY_TARGET?: string
   readonly VITE_RELEASE_SHA?: string
   readonly VITE_RELEASE_BUILT_AT?: string
   readonly VITE_FIREBASE_API_KEY?: string

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -11,19 +11,41 @@ import { resolve } from 'node:path'
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '')
   const httpsEnabled = env.VITE_HTTPS === 'true'
+  const devProxyTarget = env.VITE_DEV_PROXY_TARGET?.trim()
+  const useDevProxy = mode === 'development' && Boolean(devProxyTarget)
   const certPath = resolve(process.cwd(), env.VITE_HTTPS_CERT ?? './certs/localhost.pem')
   const keyPath = resolve(process.cwd(), env.VITE_HTTPS_KEY ?? './certs/localhost-key.pem')
   const canUseHttps = httpsEnabled && existsSync(certPath) && existsSync(keyPath)
-
-  return {
-    server: canUseHttps
+  const server = {
+    // Allow Cloudflare tunnel URLs for mobile-device testing.
+    allowedHosts: ['.trycloudflare.com'],
+    ...(useDevProxy
+      ? {
+          proxy: {
+            '/api': {
+              target: devProxyTarget,
+              changeOrigin: true,
+            },
+            '/socket.io': {
+              target: devProxyTarget,
+              changeOrigin: true,
+              ws: true,
+            },
+          },
+        }
+      : {}),
+    ...(canUseHttps
       ? {
           https: {
             cert: readFileSync(certPath),
             key: readFileSync(keyPath),
           },
         }
-      : undefined,
+      : {}),
+  }
+
+  return {
+    server,
     plugins: [
       react({
         babel: {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,106 +1,125 @@
 import { defineConfig } from 'vite'
+import { loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import { VitePWA } from 'vite-plugin-pwa'
 import { firebaseMessagingSwPlugin } from './vite-plugin-firebase-messaging-sw'
+import { existsSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [
-    react({
-      babel: {
-        plugins: ['babel-plugin-react-compiler'],
-      },
-    }),
-    tailwindcss(),
-    VitePWA({
-      registerType: 'autoUpdate',
-      includeAssets: ['icon.svg', 'apple-touch-icon.png'],
-      workbox: {
-        // Avoid terser plugin early-exit in this environment.
-        mode: 'development',
-        cleanupOutdatedCaches: true,
-        navigateFallback: '/index.html',
-        runtimeCaching: [
-          {
-            urlPattern: /^https:\/\/fonts\.(?:googleapis|gstatic)\.com\/.*/i,
-            handler: 'CacheFirst',
-            options: {
-              cacheName: 'google-fonts',
-              expiration: {
-                maxEntries: 8,
-                maxAgeSeconds: 60 * 60 * 24 * 365,
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  const httpsEnabled = env.VITE_HTTPS === 'true'
+  const certPath = resolve(process.cwd(), env.VITE_HTTPS_CERT ?? './certs/localhost.pem')
+  const keyPath = resolve(process.cwd(), env.VITE_HTTPS_KEY ?? './certs/localhost-key.pem')
+  const canUseHttps = httpsEnabled && existsSync(certPath) && existsSync(keyPath)
+
+  return {
+    server: canUseHttps
+      ? {
+          https: {
+            cert: readFileSync(certPath),
+            key: readFileSync(keyPath),
+          },
+        }
+      : undefined,
+    plugins: [
+      react({
+        babel: {
+          plugins: ['babel-plugin-react-compiler'],
+        },
+      }),
+      tailwindcss(),
+      VitePWA({
+        registerType: 'autoUpdate',
+        includeAssets: ['icon.svg', 'apple-touch-icon.png'],
+        workbox: {
+          // Avoid terser plugin early-exit in this environment.
+          mode: 'development',
+          cleanupOutdatedCaches: true,
+          navigateFallback: '/index.html',
+          runtimeCaching: [
+            {
+              urlPattern: /^https:\/\/fonts\.(?:googleapis|gstatic)\.com\/.*/i,
+              handler: 'CacheFirst',
+              options: {
+                cacheName: 'google-fonts',
+                expiration: {
+                  maxEntries: 8,
+                  maxAgeSeconds: 60 * 60 * 24 * 365,
+                },
               },
             },
-          },
-        ],
-      },
-      manifest: {
-        id: '/',
-        name: 'Chatty - Texting with AI',
-        short_name: 'Chatty',
-        description: 'A fast real-time texting app with AI.',
-        start_url: '/',
-        scope: '/',
-        display: 'standalone',
-        display_override: ['window-controls-overlay', 'standalone', 'browser'],
-        orientation: 'portrait',
-        lang: 'en',
-        dir: 'ltr',
-        theme_color: '#ffffff',
-        background_color: '#ffffff',
-        categories: ['social', 'communication', 'productivity'],
-        prefer_related_applications: false,
-        icons: [
-          {
-            src: '/pwa-192x192.png',
-            sizes: '192x192',
-            type: 'image/png',
-          },
-          {
-            src: '/pwa-512x512.png',
-            sizes: '512x512',
-            type: 'image/png',
-          },
-          {
-            src: '/pwa-512x512.png',
-            sizes: '512x512',
-            type: 'image/png',
-            purpose: 'maskable',
-          },
-          {
-            src: '/pwa/icon.svg',
-            sizes: 'any',
-            type: 'image/svg+xml',
-          },
-          {
-            src: '/pwa/maskable-icon.svg',
-            sizes: 'any',
-            type: 'image/svg+xml',
-            purpose: 'maskable',
-          },
-        ],
-        shortcuts: [
-          {
-            name: 'Open Chats',
-            short_name: 'Chats',
-            description: 'Jump directly into your conversation list.',
-            url: '/',
-            icons: [{ src: '/pwa-192x192.png', sizes: '192x192', type: 'image/png' }],
-          },
-          {
-            name: 'Login',
-            short_name: 'Login',
-            description: 'Go to the login screen quickly.',
-            url: '/login',
-            icons: [{ src: '/pwa-192x192.png', sizes: '192x192', type: 'image/png' }],
-          },
-        ],
-      },
-      devOptions: {
-        enabled: true,
-      },
-    }),
-    firebaseMessagingSwPlugin(),
-  ],
+          ],
+        },
+        manifest: {
+          id: '/',
+          name: 'Chatty - Texting with AI',
+          short_name: 'Chatty',
+          description: 'A fast real-time texting app with AI.',
+          start_url: '/',
+          scope: '/',
+          display: 'standalone',
+          display_override: ['window-controls-overlay', 'standalone', 'browser'],
+          orientation: 'portrait',
+          lang: 'en',
+          dir: 'ltr',
+          theme_color: '#ffffff',
+          background_color: '#ffffff',
+          categories: ['social', 'communication', 'productivity'],
+          prefer_related_applications: false,
+          icons: [
+            {
+              src: '/pwa-192x192.png',
+              sizes: '192x192',
+              type: 'image/png',
+            },
+            {
+              src: '/pwa-512x512.png',
+              sizes: '512x512',
+              type: 'image/png',
+            },
+            {
+              src: '/pwa-512x512.png',
+              sizes: '512x512',
+              type: 'image/png',
+              purpose: 'maskable',
+            },
+            {
+              src: '/pwa/icon.svg',
+              sizes: 'any',
+              type: 'image/svg+xml',
+            },
+            {
+              src: '/pwa/maskable-icon.svg',
+              sizes: 'any',
+              type: 'image/svg+xml',
+              purpose: 'maskable',
+            },
+          ],
+          shortcuts: [
+            {
+              name: 'Open Chats',
+              short_name: 'Chats',
+              description: 'Jump directly into your conversation list.',
+              url: '/',
+              icons: [{ src: '/pwa-192x192.png', sizes: '192x192', type: 'image/png' }],
+            },
+            {
+              name: 'Login',
+              short_name: 'Login',
+              description: 'Go to the login screen quickly.',
+              url: '/login',
+              icons: [{ src: '/pwa-192x192.png', sizes: '192x192', type: 'image/png' }],
+            },
+          ],
+        },
+        devOptions: {
+          enabled: true,
+        },
+      }),
+      firebaseMessagingSwPlugin(),
+    ],
+  }
 })


### PR DESCRIPTION
## Summary

- Centralize POP/back navigation handling and wire layout/home navigation to avoid unintended redirects.
- Add optional local HTTPS support for Vite development with configurable certificate paths and documentation for mobile PWA testing.

## Why

- Improve PWA navigation reliability on mobile and enable realistic HTTPS testing against the dev server.

## Test plan

- [ ] frontend: `npm run lint`
- [ ] frontend: `npm run typecheck`
- [ ] frontend: `npm run test`
- [ ] Manual: verify back navigation and PWA behavior on device/emulator as applicable.

## Rollback notes

- Revert this PR; restore prior `vite.config`, env examples, and navigation hooks if behavior regresses.

Made with [Cursor](https://cursor.com)